### PR TITLE
Adding hotkeys for conjuration parameters to make editing easier

### DIFF
--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -175,9 +175,11 @@ function cursorEnd(e: any) {
                 :key="i"
                 class="mb-2 flex"
               >
-                <input v-model="customArg.key"
+                <input
+                  v-model="customArg.key"
                   class="gradient-border-no-opacity relative h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
-                  placeholder="Occupation" :ref="el => { keyInputs[i] = el }" autofocus @keydown.enter="setValueFocus(i)"
+                  :ref="el => { keyInputs[i] = el }" autofocus @keydown.enter="setValueFocus(i)"
+                  placeholder="Occupation"
                   @keydown.escape="!isFirst(i) && removeCustomArg(i); setKeyFocus(i - 1)"
                   @keydown.backspace="isKeyEmpty(i) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault(); isKeyEmpty(i) && isValueEmpty(i) && removeCustomArg(i);"
                   @keydown.right="cursorEnd($event) && setValueFocus(i) && $event.preventDefault()"
@@ -185,9 +187,11 @@ function cursorEnd(e: any) {
                   @keydown.down="!isLast(i) && setKeyFocus(i + 1)"
                   @keydown.up="!isFirst(i) && setKeyFocus(i - 1)"
                 />
-                <input v-model="customArg.value"
+                <input
+                  v-model="customArg.value"
                   class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
-                  placeholder="Bartender" :ref="el => { valueInputs[i] = el }"
+                  :ref="el => { valueInputs[i] = el }"
+                  placeholder="Bartender"
                   @keydown.enter="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1)"
                   @keydown.backspace="customArg.value === '' && setKeyFocus(i) && $event.preventDefault()"
                   @keydown.tab="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1) && $event.preventDefault()"
@@ -247,7 +251,8 @@ function cursorEnd(e: any) {
         <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
           <div
             v-for="( item, i ) of summonedItems"
-            :key="i" class="cursor-pointer rounded-xl"
+            :key="i"
+            class="cursor-pointer rounded-xl"
             :class="{
               'border-2 border-green-500/50': !!selectedItems.find((a: any) => a.name === item.name),
               'border-2 border-green-500/0': !selectedItems.find((a: any) => a.name === item.name)

--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -177,9 +177,11 @@ function cursorEnd(e: any) {
               >
                 <input
                   v-model="customArg.key"
+                  :ref="el => { keyInputs[i] = el }"
                   class="gradient-border-no-opacity relative h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
-                  :ref="el => { keyInputs[i] = el }" autofocus @keydown.enter="setValueFocus(i)"
+                  autofocus
                   placeholder="Occupation"
+                  @keydown.enter="setValueFocus(i)"
                   @keydown.escape="!isFirst(i) && removeCustomArg(i); setKeyFocus(i - 1)"
                   @keydown.backspace="isKeyEmpty(i) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault(); isKeyEmpty(i) && isValueEmpty(i) && removeCustomArg(i);"
                   @keydown.right="cursorEnd($event) && setValueFocus(i) && $event.preventDefault()"
@@ -189,8 +191,8 @@ function cursorEnd(e: any) {
                 />
                 <input
                   v-model="customArg.value"
-                  class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   :ref="el => { valueInputs[i] = el }"
+                  class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   placeholder="Bartender"
                   @keydown.enter="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1)"
                   @keydown.backspace="customArg.value === '' && setKeyFocus(i) && $event.preventDefault()"
@@ -250,7 +252,7 @@ function cursorEnd(e: any) {
 
         <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
           <div
-            v-for="( item, i ) of summonedItems"
+            v-for="(item, i) of summonedItems"
             :key="i"
             class="cursor-pointer rounded-xl"
             :class="{

--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -196,7 +196,10 @@ function cursorEnd(e: any) {
                   @keydown.down="!isLast(i) && setValueFocus(i + 1)"
                   @keydown.up="!isFirst(i) && setValueFocus(i - 1)"
                 />
-                <button class="ml-2 rounded border border-red-500 p-1 px-2 text-sm" @click="removeCustomArg(i)">
+                <button
+                  class="ml-2 rounded border border-red-500 p-1 px-2 text-sm"
+                  @click="removeCustomArg(i)"
+                >
                   <XMarkIcon class="h-4 w-4" />
                 </button>
               </div>
@@ -242,11 +245,15 @@ function cursorEnd(e: any) {
         </div>
 
         <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
-          <div v-for="( item, i ) of  summonedItems " :key="i" class="cursor-pointer rounded-xl" :class="{
-            'border-2 border-green-500/50': !!selectedItems.find((a: any) => a.name === item.name),
-            'border-2 border-green-500/0': !selectedItems.find((a: any) => a.name === item.name)
-          }
-            " @click="addToSelectedItems(item)">
+          <div
+            v-for="( item, i ) of summonedItems"
+            :key="i" class="cursor-pointer rounded-xl"
+            :class="{
+              'border-2 border-green-500/50': !!selectedItems.find((a: any) => a.name === item.name),
+              'border-2 border-green-500/0': !selectedItems.find((a: any) => a.name === item.name)
+            }"
+            @click="addToSelectedItems(item)"
+          >
             <Character :character="item" full />
           </div>
         </div>

--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -147,8 +147,11 @@ function cursorEnd(e: any) {
 </script>
 
 <template>
-  <div v-if="summoner" class="relative flex h-full rounded-xl bg-cover bg-center"
-    :style="backgroundImageInlineStyle(summoner.imageUri)">
+  <div
+    v-if="summoner"
+    class="relative flex h-full rounded-xl bg-cover bg-center"
+    :style="backgroundImageInlineStyle(summoner.imageUri)"
+  >
     <div class="absolute h-full w-full rounded-xl bg-black/75 p-4"></div>
     <div class="z-10 h-full w-full rounded-xl p-4">
       <template v-if="!generating && !summonedItems.length">
@@ -167,7 +170,11 @@ function cursorEnd(e: any) {
               Add parameters to help refine your summoning
             </div>
             <div class="mt-2">
-              <div v-for="(customArg, i) in customArgs" :key="i" class="mb-2 flex">
+              <div
+                v-for="(customArg, i) in customArgs"
+                :key="i"
+                class="mb-2 flex"
+              >
                 <input v-model="customArg.key"
                   class="gradient-border-no-opacity relative h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   placeholder="Occupation" :ref="el => { keyInputs[i] = el }" autofocus @keydown.enter="setValueFocus(i)"
@@ -175,7 +182,9 @@ function cursorEnd(e: any) {
                   @keydown.backspace="isKeyEmpty(i) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault(); isKeyEmpty(i) && isValueEmpty(i) && removeCustomArg(i);"
                   @keydown.right="cursorEnd($event) && setValueFocus(i) && $event.preventDefault()"
                   @keydown.left="cursorStart($event) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault()"
-                  @keydown.down="!isLast(i) && setKeyFocus(i + 1)" @keydown.up="!isFirst(i) && setKeyFocus(i - 1)" />
+                  @keydown.down="!isLast(i) && setKeyFocus(i + 1)"
+                  @keydown.up="!isFirst(i) && setKeyFocus(i - 1)"
+                />
                 <input v-model="customArg.value"
                   class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   placeholder="Bartender" :ref="el => { valueInputs[i] = el }"
@@ -184,20 +193,27 @@ function cursorEnd(e: any) {
                   @keydown.tab="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1) && $event.preventDefault()"
                   @keydown.right="cursorEnd($event) && !isLast(i) && setKeyFocus(i + 1) && $event.preventDefault()"
                   @keydown.left="cursorStart($event) && setKeyFocus(i) && $event.preventDefault()"
-                  @keydown.down="!isLast(i) && setValueFocus(i + 1)" @keydown.up="!isFirst(i) && setValueFocus(i - 1)" />
+                  @keydown.down="!isLast(i) && setValueFocus(i + 1)"
+                  @keydown.up="!isFirst(i) && setValueFocus(i - 1)"
+                />
                 <button class="ml-2 rounded border border-red-500 p-1 px-2 text-sm" @click="removeCustomArg(i)">
                   <XMarkIcon class="h-4 w-4" />
                 </button>
               </div>
-              <button class="rounded border border-green-500 p-1 px-4 text-sm" @click="addCustomArg">
+              <button
+                class="rounded border border-green-500 p-1 px-4 text-sm"
+                @click="addCustomArg"
+              >
                 Add parameter
               </button>
             </div>
           </div>
         </div>
 
-        <button class="mt-8 flex cursor-pointer rounded-xl bg-black bg-gradient px-4 py-2 text-lg font-bold text-white"
-          @click="generate(summoner.code)">
+        <button
+          class="mt-8 flex cursor-pointer rounded-xl bg-black bg-gradient px-4 py-2 text-lg font-bold text-white"
+          @click="generate(summoner.code)"
+        >
           <span class="self-center"> Begin Summoning </span>
         </button>
       </template>
@@ -212,11 +228,15 @@ function cursorEnd(e: any) {
             you'd like to save!
           </div>
 
-          <button class="rounded-xl px-4 py-2" :class="{
-            'bg-green-500': selectedItems.length,
-            'bg-gray-700/50': !selectedItems.length,
-          }
-            " :disabled="!selectedItems.length" @click="clickSaveCharacters">
+          <button
+            class="rounded-xl px-4 py-2"
+            :class="{
+              'bg-green-500': selectedItems.length,
+              'bg-gray-700/50': !selectedItems.length,
+            }"
+            :disabled="!selectedItems.length"
+            @click="clickSaveCharacters"
+          >
             Save {{ summoner.name }}
           </button>
         </div>

--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -127,10 +127,10 @@ function setValueFocus(index: number) {
   return true;
 }
 function isFirst(index: number) {
-  return (index + 1) === 1;
+  return index + 1 === 1;
 }
 function isLast(index: number) {
-  return (index + 1) === customArgs.value.length;
+  return index + 1 === customArgs.value.length;
 }
 function isKeyEmpty(index: number) {
   return keyInputs.value[index].value === "";
@@ -176,29 +176,74 @@ function cursorEnd(e: any) {
                 class="mb-2 flex"
               >
                 <input
-                  :ref="el => { keyInputs[i] = el }"
+                  :ref="
+                    (el) => {
+                      keyInputs[i] = el;
+                    }
+                  "
                   v-model="customArg.key"
                   class="gradient-border-no-opacity relative h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   autofocus
                   placeholder="Occupation"
                   @keydown.enter="setValueFocus(i)"
-                  @keydown.escape="!isFirst(i) && removeCustomArg(i); setKeyFocus(i - 1)"
-                  @keydown.backspace="isKeyEmpty(i) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault(); isKeyEmpty(i) && isValueEmpty(i) && removeCustomArg(i);"
-                  @keydown.right="cursorEnd($event) && setValueFocus(i) && $event.preventDefault()"
-                  @keydown.left="cursorStart($event) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault()"
+                  @keydown.escape="
+                    !isFirst(i) && removeCustomArg(i);
+                    setKeyFocus(i - 1);
+                  "
+                  @keydown.backspace="
+                    isKeyEmpty(i) &&
+                      !isFirst(i) &&
+                      setValueFocus(i - 1) &&
+                      $event.preventDefault();
+                    isKeyEmpty(i) && isValueEmpty(i) && removeCustomArg(i);
+                  "
+                  @keydown.right="
+                    cursorEnd($event) &&
+                      setValueFocus(i) &&
+                      $event.preventDefault()
+                  "
+                  @keydown.left="
+                    cursorStart($event) &&
+                      !isFirst(i) &&
+                      setValueFocus(i - 1) &&
+                      $event.preventDefault()
+                  "
                   @keydown.down="!isLast(i) && setKeyFocus(i + 1)"
                   @keydown.up="!isFirst(i) && setKeyFocus(i - 1)"
                 />
                 <input
-                  :ref="el => { valueInputs[i] = el }"
+                  :ref="
+                    (el) => {
+                      valueInputs[i] = el;
+                    }
+                  "
                   v-model="customArg.value"
                   class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   placeholder="Bartender"
-                  @keydown.enter="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1)"
-                  @keydown.backspace="customArg.value === '' && setKeyFocus(i) && $event.preventDefault()"
-                  @keydown.tab="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1) && $event.preventDefault()"
-                  @keydown.right="cursorEnd($event) && !isLast(i) && setKeyFocus(i + 1) && $event.preventDefault()"
-                  @keydown.left="cursorStart($event) && setKeyFocus(i) && $event.preventDefault()"
+                  @keydown.enter="
+                    i + 1 === customArgs.length && addCustomArg();
+                    setKeyFocus(i + 1);
+                  "
+                  @keydown.backspace="
+                    customArg.value === '' &&
+                      setKeyFocus(i) &&
+                      $event.preventDefault()
+                  "
+                  @keydown.tab="
+                    i + 1 === customArgs.length && addCustomArg();
+                    setKeyFocus(i + 1) && $event.preventDefault();
+                  "
+                  @keydown.right="
+                    cursorEnd($event) &&
+                      !isLast(i) &&
+                      setKeyFocus(i + 1) &&
+                      $event.preventDefault()
+                  "
+                  @keydown.left="
+                    cursorStart($event) &&
+                      setKeyFocus(i) &&
+                      $event.preventDefault()
+                  "
                   @keydown.down="!isLast(i) && setValueFocus(i + 1)"
                   @keydown.up="!isFirst(i) && setValueFocus(i - 1)"
                 />

--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -176,8 +176,8 @@ function cursorEnd(e: any) {
                 class="mb-2 flex"
               >
                 <input
-                  v-model="customArg.key"
                   :ref="el => { keyInputs[i] = el }"
+                  v-model="customArg.key"
                   class="gradient-border-no-opacity relative h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   autofocus
                   placeholder="Occupation"
@@ -190,8 +190,8 @@ function cursorEnd(e: any) {
                   @keydown.up="!isFirst(i) && setKeyFocus(i - 1)"
                 />
                 <input
-                  v-model="customArg.value"
                   :ref="el => { valueInputs[i] = el }"
+                  v-model="customArg.value"
                   class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
                   placeholder="Bartender"
                   @keydown.enter="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1)"

--- a/ui/src/components/Conjuration/ViewConjurer.vue
+++ b/ui/src/components/Conjuration/ViewConjurer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, ref, nextTick } from "vue";
 import {
   CustomArg,
   getConjurer,
@@ -107,19 +107,48 @@ function addToSelectedItems(item: any) {
 
 function addCustomArg() {
   customArgs.value.push({ key: "", value: "" });
+  return true;
 }
 
 function removeCustomArg(index: number) {
   customArgs.value.splice(index, 1);
 }
+
+const keyInputs = ref<any[]>([]);
+const valueInputs = ref<any[]>([]);
+function setKeyFocus(index: number) {
+  nextTick(() => {
+    keyInputs.value[index].focus();
+  });
+  return true;
+}
+function setValueFocus(index: number) {
+  valueInputs.value[index].focus();
+  return true;
+}
+function isFirst(index: number) {
+  return (index + 1) === 1;
+}
+function isLast(index: number) {
+  return (index + 1) === customArgs.value.length;
+}
+function isKeyEmpty(index: number) {
+  return keyInputs.value[index].value === "";
+}
+function isValueEmpty(index: number) {
+  return valueInputs.value[index].value === "";
+}
+function cursorStart(e: any) {
+  return e.target.selectionStart === 0;
+}
+function cursorEnd(e: any) {
+  return e.target.selectionStart === e.target.value.length;
+}
 </script>
 
 <template>
-  <div
-    v-if="summoner"
-    class="relative flex h-full rounded-xl bg-cover bg-center"
-    :style="backgroundImageInlineStyle(summoner.imageUri)"
-  >
+  <div v-if="summoner" class="relative flex h-full rounded-xl bg-cover bg-center"
+    :style="backgroundImageInlineStyle(summoner.imageUri)">
     <div class="absolute h-full w-full rounded-xl bg-black/75 p-4"></div>
     <div class="z-10 h-full w-full rounded-xl p-4">
       <template v-if="!generating && !summonedItems.length">
@@ -138,42 +167,37 @@ function removeCustomArg(index: number) {
               Add parameters to help refine your summoning
             </div>
             <div class="mt-2">
-              <div
-                v-for="(customArg, i) in customArgs"
-                :key="i"
-                class="mb-2 flex"
-              >
-                <input
-                  v-model="customArg.key"
+              <div v-for="(customArg, i) in customArgs" :key="i" class="mb-2 flex">
+                <input v-model="customArg.key"
                   class="gradient-border-no-opacity relative h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
-                  placeholder="Occupation"
-                />
-                <input
-                  v-model="customArg.value"
+                  placeholder="Occupation" :ref="el => { keyInputs[i] = el }" autofocus @keydown.enter="setValueFocus(i)"
+                  @keydown.escape="!isFirst(i) && removeCustomArg(i); setKeyFocus(i - 1)"
+                  @keydown.backspace="isKeyEmpty(i) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault(); isKeyEmpty(i) && isValueEmpty(i) && removeCustomArg(i);"
+                  @keydown.right="cursorEnd($event) && setValueFocus(i) && $event.preventDefault()"
+                  @keydown.left="cursorStart($event) && !isFirst(i) && setValueFocus(i - 1) && $event.preventDefault()"
+                  @keydown.down="!isLast(i) && setKeyFocus(i + 1)" @keydown.up="!isFirst(i) && setKeyFocus(i - 1)" />
+                <input v-model="customArg.value"
                   class="gradient-border-no-opacity relative ml-2 h-8 w-32 rounded-xl border bg-black px-4 text-left text-white"
-                  placeholder="Bartender"
-                />
-                <button
-                  class="ml-2 rounded border border-red-500 p-1 px-2 text-sm"
-                  @click="removeCustomArg(i)"
-                >
+                  placeholder="Bartender" :ref="el => { valueInputs[i] = el }"
+                  @keydown.enter="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1)"
+                  @keydown.backspace="customArg.value === '' && setKeyFocus(i) && $event.preventDefault()"
+                  @keydown.tab="(i + 1) === customArgs.length && addCustomArg(); setKeyFocus(i + 1) && $event.preventDefault()"
+                  @keydown.right="cursorEnd($event) && !isLast(i) && setKeyFocus(i + 1) && $event.preventDefault()"
+                  @keydown.left="cursorStart($event) && setKeyFocus(i) && $event.preventDefault()"
+                  @keydown.down="!isLast(i) && setValueFocus(i + 1)" @keydown.up="!isFirst(i) && setValueFocus(i - 1)" />
+                <button class="ml-2 rounded border border-red-500 p-1 px-2 text-sm" @click="removeCustomArg(i)">
                   <XMarkIcon class="h-4 w-4" />
                 </button>
               </div>
-              <button
-                class="rounded border border-green-500 p-1 px-4 text-sm"
-                @click="addCustomArg"
-              >
+              <button class="rounded border border-green-500 p-1 px-4 text-sm" @click="addCustomArg">
                 Add parameter
               </button>
             </div>
           </div>
         </div>
 
-        <button
-          class="mt-8 flex cursor-pointer rounded-xl bg-black bg-gradient px-4 py-2 text-lg font-bold text-white"
-          @click="generate(summoner.code)"
-        >
+        <button class="mt-8 flex cursor-pointer rounded-xl bg-black bg-gradient px-4 py-2 text-lg font-bold text-white"
+          @click="generate(summoner.code)">
           <span class="self-center"> Begin Summoning </span>
         </button>
       </template>
@@ -188,30 +212,21 @@ function removeCustomArg(index: number) {
             you'd like to save!
           </div>
 
-          <button
-            class="rounded-xl px-4 py-2"
-            :class="{
-              'bg-green-500': selectedItems.length,
-              'bg-gray-700/50': !selectedItems.length,
-            }"
-            :disabled="!selectedItems.length"
-            @click="clickSaveCharacters"
-          >
+          <button class="rounded-xl px-4 py-2" :class="{
+            'bg-green-500': selectedItems.length,
+            'bg-gray-700/50': !selectedItems.length,
+          }
+            " :disabled="!selectedItems.length" @click="clickSaveCharacters">
             Save {{ summoner.name }}
           </button>
         </div>
 
         <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
-          <div
-            v-for="(item, i) of summonedItems"
-            :key="i"
-            class="cursor-pointer rounded-xl"
-            :class="{
-              'border-2 border-green-500/50': !!selectedItems.find((a: any) => a.name === item.name),
-              'border-2 border-green-500/0': !selectedItems.find((a: any) => a.name === item.name)
-            }"
-            @click="addToSelectedItems(item)"
-          >
+          <div v-for="( item, i ) of  summonedItems " :key="i" class="cursor-pointer rounded-xl" :class="{
+            'border-2 border-green-500/50': !!selectedItems.find((a: any) => a.name === item.name),
+            'border-2 border-green-500/0': !selectedItems.find((a: any) => a.name === item.name)
+          }
+            " @click="addToSelectedItems(item)">
             <Character :character="item" full />
           </div>
         </div>


### PR DESCRIPTION
Adding hotkeys to conjurer page's parameter inputs to make adding, editing, and navigating parameters faster. The following hotkeys were added:

- Navigate which parameter input is focused using up down left right keys
- Delete parameter using esc
- Delete empty parameter when backspacing in an empty key input
- Create new parameter group using enter key in value input of last parameter
- Tab through parameters