### PR TITLE
110 conjuration scalability improvements

### DIFF
--- a/api/controllers/generators.ts
+++ b/api/controllers/generators.ts
@@ -11,19 +11,14 @@ import {
   Body,
 } from "tsoa";
 import { prisma } from "../lib/providers/prisma";
-import { Campaign, Conjuration } from "@prisma/client";
-import { sanitizeJson } from "../lib/utils";
+import { Conjuration } from "@prisma/client";
 import { AppError, HttpCode } from "../lib/errors/AppError";
 import { parentLogger } from "../lib/logger";
-import { getClient } from "../lib/providers/openai";
 import conjurers, { Generator, getGenerator } from "../data/conjurers";
-import { getRpgSystem } from "../data/rpgSystems";
-import { generateImage } from "../services/imageGeneration";
 import { AppEvent, track, TrackingInfo } from "../lib/tracking";
-import { processTagsQueue } from "../worker";
+import { conjureQueue } from "../worker";
 
 const logger = parentLogger.getSubLogger();
-const openai = getClient();
 
 export interface GetGeneratorsResponse {
   data: any[];
@@ -33,16 +28,8 @@ export interface GetGeneratorsResponse {
 
 export interface PostGeneratorGenerate {
   campaignId: number;
-  customArgs?: CustomArg[];
-}
-
-export interface CustomArg {
-  key: string;
-  value: any;
-}
-
-interface PostGenerateCharacterImageRequest {
-  looks: string;
+  count: number;
+  customArgs?: any[];
 }
 
 @Route("generators")
@@ -78,18 +65,6 @@ export class GeneratorController {
   ): Generator | undefined {
     track(AppEvent.GetConjurer, userId, trackingInfo);
     return getGenerator(code);
-  }
-
-  @Security("jwt")
-  @OperationId("generateCharacterImage")
-  @Post("/image")
-  public async postGenerateCharacterImage(
-    @Inject() userId: number,
-    @Inject() trackingInfo: TrackingInfo,
-    @Body() request: PostGenerateCharacterImageRequest
-  ): Promise<any> {
-    track(AppEvent.ConjureImage, userId, trackingInfo);
-    return await getImageForPrompt(request.looks, 3);
   }
 
   @Post("/{code}/generate/quick")
@@ -180,156 +155,63 @@ export class GeneratorController {
 
     track(AppEvent.Conjure, userId, trackingInfo);
 
-    return await conjure(generator, request.customArgs, campaign);
+    const conjurationRequest = await prisma.conjurationRequest.create({
+      data: {
+        userId,
+        campaignId: request.campaignId,
+        generatorCode: code,
+        count: request.count,
+        args: request.customArgs || [],
+      },
+    });
+
+    await conjureQueue.add({
+      count: request.count,
+      campaignId: request.campaignId,
+      generatorCode: code,
+      args: request.customArgs || [],
+      conjurationRequestId: conjurationRequest.id,
+    });
+
+    return {
+      conjurationRequestId: conjurationRequest.id,
+    };
+  }
+  @Get("/requests/{conjurationRequestId}")
+  @Security("jwt")
+  @OperationId("getConjurationRequest")
+  public async getConjurationRequest(
+    @Inject() userId: number,
+    @Inject() trackingInfo: TrackingInfo,
+    @Path() conjurationRequestId: number
+  ): Promise<any> {
+    track(AppEvent.GetConjurationRequests, userId, trackingInfo);
+
+    return prisma.conjurationRequest.findUnique({
+      where: {
+        id: conjurationRequestId,
+        userId,
+      },
+      include: {
+        conjurations: {
+          include: {
+            copies: {
+              where: {
+                userId: userId,
+              },
+              select: {
+                id: true,
+              },
+            },
+          },
+          where: {
+            userId: null,
+          },
+          orderBy: {
+            createdAt: "asc",
+          },
+        },
+      },
+    });
   }
 }
-
-export const conjure = async (
-  generator: Generator,
-  customArgs: CustomArg[] = [],
-  campaign?: Campaign | undefined
-) => {
-  const prompt = buildPrompt(generator, campaign, customArgs);
-
-  let conjurations: any = undefined;
-
-  do {
-    let response: any;
-
-    try {
-      response = await openai.createCompletion({
-        model: "text-davinci-003",
-        prompt,
-        max_tokens: 3500,
-      });
-    } catch (err: any) {
-      logger.error("Error generating character with openai", err.response.data);
-    }
-
-    if (!response) {
-      throw new AppError({
-        description: "Error generating character.",
-        httpCode: HttpCode.INTERNAL_SERVER_ERROR,
-      });
-    }
-
-    const generatedJson = response.data.choices[0].text?.trim() || "";
-    logger.info("Received json from openai", generatedJson);
-
-    const charString = sanitizeJson(generatedJson);
-    logger.info("Sanitized json from openai...", charString);
-
-    try {
-      conjurations = JSON.parse(charString || "");
-    } catch (e) {
-      logger.warn("Failed to parse character string", e, charString);
-    }
-  } while (!conjurations);
-
-  const promises = conjurations.map((c: any) =>
-    generateImage(c.imageAIPrompt, 1)
-  );
-  const results = await Promise.all(promises);
-
-  for (let i = 0; i < conjurations.length; i++) {
-    conjurations[i].imageUri = results[i][0];
-  }
-
-  const result = await prisma.$transaction(
-    conjurations.map((c: any) =>
-      prisma.conjuration.create({
-        data: {
-          name: c.name,
-          data: {
-            ...c,
-            name: undefined,
-            imageAIPrompt: undefined,
-            imageUri: undefined,
-            tags: undefined,
-          },
-          imageAIPrompt: c.imageAIPrompt,
-          imageUri: c.imageUri,
-          conjurerCode: generator.code || "",
-          tags: [
-            generator.code,
-            ...(c.tags ? c.tags.map((t: string) => t.toLowerCase()) : []),
-          ],
-        },
-      })
-    )
-  );
-
-  await processTagsQueue.add({
-    conjurationIds: result.map((r) => r.id),
-  });
-};
-
-const buildPrompt = (
-  generator: Generator,
-  campaign?: Campaign | undefined,
-  customArgs: CustomArg[] = []
-) => {
-  let prompt = `You are a master storyteller. Please generate me 3 unique ${generator.name.toLowerCase()}`;
-
-  if (campaign) {
-    const rpgSystem = getRpgSystem(campaign.rpgSystemCode);
-    const publicAdventure = rpgSystem?.publicAdventures?.find(
-      (a) => a.code === campaign.publicAdventureCode
-    );
-
-    if (!rpgSystem) {
-      throw new AppError({
-        description: "RPG System not found.",
-        httpCode: HttpCode.BAD_REQUEST,
-      });
-    }
-
-    prompt += ` to be used in ${rpgSystem.name}`;
-
-    if (publicAdventure) {
-      prompt += `for the campaign ${publicAdventure?.name}. `;
-    } else {
-      prompt += ". ";
-    }
-  } else {
-    prompt += " to be used in a roleplaying game like dungeons and dragons. ";
-  }
-
-  if (customArgs.length > 0) {
-    prompt += `Please use the following parameters to guide generation: ${customArgs
-      .map((a) => `${a.key}: ${a.value}`)
-      .join(", ")}. `;
-  }
-
-  prompt += `Please focus on generating 3 distinctly unique and different ${generator.name.toLowerCase()} with really engaging, immersive and compelling attributes. Please return JSON only so that I can easily deserialize into a javascript object. Use the following format. ${
-    generator.formatPrompt
-  }. `;
-
-  if (generator.allowsImageGeneration) {
-    prompt += `Please generate a prompt to be used by an AI image generator to generate an portrait image for this ${generator.name.toLowerCase()} to be stored in the JSON property 'imageAIPrompt'. ${
-      generator.imagePromptExtraContext
-    }. `;
-  }
-
-  if (generator.basePromptExtraContext) {
-    prompt += generator.basePromptExtraContext;
-  }
-
-  logger.info("Built prompt", prompt);
-
-  return prompt;
-};
-
-export const getImageForPrompt = async (prompt: string, count: number) => {
-  prompt = `${prompt.replace(
-    ".",
-    ""
-  )}, medieval, fantasy, portrait, oil painting style`;
-
-  const response = await openai.createImage({
-    prompt,
-    n: count,
-  });
-
-  return response.data.data;
-};

--- a/api/data/conjurers.ts
+++ b/api/data/conjurers.ts
@@ -29,7 +29,7 @@ const conjurers: Generator[] = [
     description: "Create rich, detailed characters to populate your world.",
     imageUri: "characters.png",
     formatPrompt:
-      '[{ \n      "name": "", \n      "looks": "", \n      "imageAIPrompt": "", \n      "personality": "",\n      "background": ""\n      "tags": [""]\n    }]',
+      '{ \n      "name": "", \n      "looks": "", \n      "imageAIPrompt": "", \n      "personality": "",\n      "quirks": ""\n      "fears": ""\n      "hobbies": ""\n      "background": ""\n      "tags": [""]\n    }',
     allowsImageGeneration: true,
     imagePromptExtraContext:
       "Include the character's TTRPG class, gender, facial features and clothing.",
@@ -60,7 +60,7 @@ const conjurers: Generator[] = [
     description: "Explore exotic locations in your world.",
     imageUri: "locations.png",
     formatPrompt:
-      '[{ \n      "name": "", \n      "history": "", \n      "imageAIPrompt": "", \n      "tags": [""]\n    }]',
+      '{ "name": "", "history": "", "imageAIPrompt": "", "tags": [""] }',
     allowsImageGeneration: true,
     basePromptExtraContext:
       "Please thoroughly flesh out the location's history, including historical events, climate and unique look, using at least 100 words to describe the history of this location. Please populate tags with any values you think applicable to this location, to allow easy searching.",

--- a/api/lib/tracking.ts
+++ b/api/lib/tracking.ts
@@ -27,6 +27,7 @@ export enum AppEvent {
   ConjureImage = "Conjure Image",
   QuickConjure = "Quick Conjure",
   Conjure = "Conjure",
+  GetConjurationRequests = "Get Conjuration Requests",
   GetRpgSystems = "Get Rpg Systems",
   GetSessions = "Get Sessions",
   GetSession = "Get Session",
@@ -66,8 +67,6 @@ export const extractTrackingInfo = (req: Request): TrackingInfo => {
   )
     .split(",")[0]
     .trim();
-
-  logger.info("Retrieved ip address: ", ip);
 
   return {
     browser: parser.getBrowser().name,

--- a/api/lib/trackingMiddleware.ts
+++ b/api/lib/trackingMiddleware.ts
@@ -1,17 +1,12 @@
 import { extractTrackingInfo } from "./tracking";
 import { NextFunction, Request, Response } from "express";
-import { Logger } from "tslog";
-const logger = new Logger();
 
 export const useInjectTrackingInfo = async (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
-  const trackingInfo = extractTrackingInfo(req);
-
-  logger.info("Injecting tracking info ", trackingInfo);
-  res.locals.trackingInfo = trackingInfo;
+  res.locals.trackingInfo = extractTrackingInfo(req);
 
   next();
 };

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -29,9 +29,13 @@ export function sanitizeJson(json: string): string {
 
   logger.info("Json was invalid, attempting to clean...");
 
-  const jsonStart = Array.from(json).findIndex((char) => char === "[");
+  const jsonStart = Array.from(json).findIndex((char) => char === "{");
   json = json.slice(jsonStart);
-  json = json.replace(/ {4}|[\t\n\r]/gm, "");
+  json = json.replace(/ {4}|[\t\n\r]/gm, " ");
+
+  if (isValidJson(json)) {
+    return json;
+  }
 
   //escape unescaped quotes in json
   let quotesOpen = false;

--- a/api/prisma/migrations/20230821225948_add_conjuration_requests/migration.sql
+++ b/api/prisma/migrations/20230821225948_add_conjuration_requests/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `conjurationId` on the `conjurations` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "comments" ADD COLUMN     "conjurationRequestId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "conjurations" DROP COLUMN "conjurationId",
+ADD COLUMN     "conjurationRequestId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "conjuration_requests" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) DEFAULT (now() AT TIME ZONE 'utc'::text),
+    "updatedAt" TIMESTAMPTZ(6) DEFAULT (now() AT TIME ZONE 'utc'::text),
+    "userId" INTEGER,
+    "args" JSONB NOT NULL,
+
+    CONSTRAINT "conjuration_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "conjurations" ADD CONSTRAINT "conjurations_conjurationRequestId_fkey" FOREIGN KEY ("conjurationRequestId") REFERENCES "conjuration_requests"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "conjuration_requests" ADD CONSTRAINT "conjuration_requests_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/migrations/20230821234209_add_campaign_id_conjuration_requests/migration.sql
+++ b/api/prisma/migrations/20230821234209_add_campaign_id_conjuration_requests/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - Added the required column `campaignId` to the `conjuration_requests` table without a default value. This is not possible if the table is not empty.
+  - Made the column `userId` on table `conjuration_requests` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "conjuration_requests" DROP CONSTRAINT "conjuration_requests_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "conjuration_requests" ADD COLUMN     "campaignId" INTEGER NOT NULL,
+ALTER COLUMN "userId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "conjuration_requests" ADD CONSTRAINT "conjuration_requests_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/migrations/20230821234255_add_count_and_generator_code_conjuration_requests/migration.sql
+++ b/api/prisma/migrations/20230821234255_add_count_and_generator_code_conjuration_requests/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `count` to the `conjuration_requests` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `generatorCode` to the `conjuration_requests` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "conjuration_requests" ADD COLUMN     "count" INTEGER NOT NULL,
+ADD COLUMN     "generatorCode" TEXT NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -27,22 +27,25 @@ model User {
   updatedAt DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
   email     String    @unique
 
-  refreshTokens RefreshToken[]
-  campaigns     Campaign[]
-  sessions      Session[]
-  comments      Comment[]
-  Conjuration   Conjuration[]
+  refreshTokens      RefreshToken[]
+  campaigns          Campaign[]
+  sessions           Session[]
+  comments           Comment[]
+  Conjuration        Conjuration[]
+  ConjurationRequest ConjurationRequest[]
 
   @@map("users")
 }
 
 model Conjuration {
-  id         Int       @id @default(autoincrement())
-  createdAt  DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
-  updatedAt  DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
-  originalId Int?
-  userId     Int?
-  campaignId Int?
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
+  updatedAt DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
+
+  originalId           Int?
+  userId               Int?
+  campaignId           Int?
+  conjurationRequestId Int?
 
   name          String
   conjurerCode  String
@@ -51,14 +54,31 @@ model Conjuration {
   data          Json
   tags          String[]
 
-  user          User?         @relation(fields: [userId], references: [id])
-  campaign      Campaign?     @relation(fields: [campaignId], references: [id])
-  original      Conjuration?  @relation("OriginalConjuration", fields: [originalId], references: [id])
-  copies        Conjuration[] @relation("OriginalConjuration")
-  comments      Comment[]
-  conjurationId Int?
+  user               User?               @relation(fields: [userId], references: [id])
+  campaign           Campaign?           @relation(fields: [campaignId], references: [id])
+  original           Conjuration?        @relation("OriginalConjuration", fields: [originalId], references: [id])
+  copies             Conjuration[]       @relation("OriginalConjuration")
+  comments           Comment[]
+  conjurationRequest ConjurationRequest? @relation(fields: [conjurationRequestId], references: [id])
 
   @@map("conjurations")
+}
+
+model ConjurationRequest {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
+  updatedAt DateTime? @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @db.Timestamptz(6)
+
+  userId        Int
+  campaignId    Int
+  generatorCode String
+  count         Int
+  args          Json
+
+  user         User?         @relation(fields: [userId], references: [id])
+  conjurations Conjuration[]
+
+  @@map("conjuration_requests")
 }
 
 model Campaign {
@@ -112,10 +132,11 @@ model Comment {
 
   text String
 
-  user         User         @relation(fields: [userId], references: [id])
-  session      Session?     @relation(fields: [sessionId], references: [id])
-  campaign     Campaign?    @relation(fields: [campaignId], references: [id])
-  conjurations Conjuration? @relation(fields: [conjurationId], references: [id])
+  user                 User         @relation(fields: [userId], references: [id])
+  session              Session?     @relation(fields: [sessionId], references: [id])
+  campaign             Campaign?    @relation(fields: [campaignId], references: [id])
+  conjurations         Conjuration? @relation(fields: [conjurationId], references: [id])
+  conjurationRequestId Int?
 
   @@map("comments")
 }

--- a/api/routes/generators.ts
+++ b/api/routes/generators.ts
@@ -82,6 +82,7 @@ router.post("/:generatorCode/generate/quick", [
 
 const postGeneratorGenerateSchema = z.object({
   campaignId: z.coerce.number(),
+  count: z.coerce.number().min(1).max(5).default(1),
   customArgs: z
     .array(
       z.object({
@@ -114,21 +115,26 @@ router.post("/:generatorCode/generate", [
   },
 ]);
 
-const postGenerateCharacterImageSchema = z.object({
-  looks: z.string().min(0).max(2000),
+const conjurationRequestIdSchema = z.object({
+  conjurationRequestId: z.coerce.number(),
 });
 
-router.post("/image", [
+router.get("/requests/:conjurationRequestId", [
   useAuthenticateRequest(),
-  useValidateRequest(postGenerateCharacterImageSchema),
+  useValidateRequest(conjurationRequestIdSchema, {
+    validationType: ValidationTypes.Route,
+  }),
   async (req: Request, res: Response) => {
     const controller = new GeneratorController();
 
-    const response = await controller.postGenerateCharacterImage(
+    const { conjurationRequestId = 0 } = req.params;
+
+    const response = await controller.getConjurationRequest(
       res.locals.auth.userId,
       res.locals.trackingInfo,
-      req.body
+      conjurationRequestId as number
     );
+
     return res.status(200).send(response);
   },
 ]);

--- a/api/worker/jobs/conjure.ts
+++ b/api/worker/jobs/conjure.ts
@@ -1,0 +1,173 @@
+import { Generator, getGenerator } from "../../data/conjurers";
+import { Campaign } from "@prisma/client";
+import { AppError, HttpCode } from "../../lib/errors/AppError";
+import { sanitizeJson, trimPlural } from "../../lib/utils";
+import { generateImage } from "../../services/imageGeneration";
+import { prisma } from "../../lib/providers/prisma";
+import { ConjureEvent, processTagsQueue } from "../index";
+import { getRpgSystem } from "../../data/rpgSystems";
+import { getClient } from "../../lib/providers/openai";
+import { parentLogger } from "../../lib/logger";
+
+const logger = parentLogger.getSubLogger();
+const openai = getClient();
+
+export const conjure = async (request: ConjureEvent) => {
+  const generator = getGenerator(request.generatorCode);
+
+  if (!generator) {
+    throw new AppError({
+      description: "Generator not found.",
+      httpCode: HttpCode.BAD_REQUEST,
+    });
+  }
+
+  const campaign = await prisma.campaign.findUnique({
+    where: {
+      id: request.campaignId,
+    },
+  });
+
+  if (!campaign) {
+    throw new AppError({
+      description: "Campaign not found.",
+      httpCode: HttpCode.BAD_REQUEST,
+    });
+  }
+
+  const prompt = buildPrompt(generator, campaign, request.args);
+
+  let conjuration: any = undefined;
+
+  do {
+    let response: any;
+
+    try {
+      response = await openai.createCompletion({
+        model: "text-davinci-003",
+        prompt,
+        max_tokens: 3500,
+      });
+    } catch (err: any) {
+      logger.error("Error generating character with openai", err.response.data);
+    }
+
+    if (!response) {
+      throw new AppError({
+        description: "Error generating character.",
+        httpCode: HttpCode.INTERNAL_SERVER_ERROR,
+      });
+    }
+
+    const generatedJson = response.data.choices[0].text?.trim() || "";
+    logger.info("Received json from openai", generatedJson);
+
+    const conjurationString = sanitizeJson(generatedJson);
+    logger.info("Sanitized json from openai...", conjurationString);
+
+    try {
+      conjuration = JSON.parse(conjurationString || "");
+    } catch (e) {
+      logger.warn("Failed to parse conjuration string", e, generatedJson);
+    }
+  } while (!conjuration || !conjuration?.imageAIPrompt);
+
+  const createdConjuration = await prisma.conjuration.create({
+    data: {
+      name: conjuration.name,
+      data: {
+        ...conjuration,
+        name: undefined,
+        imageAIPrompt: undefined,
+        imageUri: undefined,
+        tags: undefined,
+      },
+      imageAIPrompt: conjuration.imageAIPrompt,
+      imageUri: conjuration.imageUri,
+      conjurerCode: generator.code || "",
+      tags: [
+        generator.code,
+        ...(conjuration.tags
+          ? conjuration.tags.map((t: string) => t.toLowerCase())
+          : []),
+      ],
+      conjurationRequestId: request.conjurationRequestId,
+    },
+  });
+
+  conjuration.imageUri = (await generateImage(conjuration.imageAIPrompt, 1))[0];
+  await prisma.conjuration.update({
+    where: {
+      id: createdConjuration.id,
+    },
+    data: {
+      imageUri: conjuration.imageUri,
+    },
+  });
+
+  await processTagsQueue.add({
+    conjurationIds: [createdConjuration.id],
+  });
+};
+
+const buildPrompt = (
+  generator: Generator,
+  campaign?: Campaign | undefined,
+  customArgs: any[] = []
+) => {
+  let prompt = `You are a master storyteller. Please generate me a unique ${trimPlural(
+    generator.name.toLowerCase()
+  )}`;
+
+  if (campaign) {
+    const rpgSystem = getRpgSystem(campaign.rpgSystemCode);
+    const publicAdventure = rpgSystem?.publicAdventures?.find(
+      (a) => a.code === campaign.publicAdventureCode
+    );
+
+    if (!rpgSystem) {
+      throw new AppError({
+        description: "RPG System not found.",
+        httpCode: HttpCode.BAD_REQUEST,
+      });
+    }
+
+    prompt += ` to be used in ${rpgSystem.name}`;
+
+    if (publicAdventure) {
+      prompt += `for the campaign ${publicAdventure?.name}. `;
+    } else {
+      prompt += ". ";
+    }
+  } else {
+    prompt += " to be used in a roleplaying game like dungeons and dragons. ";
+  }
+
+  if (customArgs.length > 0) {
+    prompt += `Please use the following parameters to guide generation: ${customArgs
+      .map((a) => `${a.key}: ${a.value}`)
+      .join(", ")}. `;
+  }
+
+  prompt += `Please focus on generating a distinctly unique and different ${trimPlural(
+    generator.name.toLowerCase()
+  )} with really engaging, immersive and compelling attributes. Please return JSON only so that I can easily deserialize into a javascript object. Use the following format. ${
+    generator.formatPrompt
+  }. Please escape any double quotes in any JSON properties with a backslash.`;
+
+  if (generator.allowsImageGeneration) {
+    prompt += `Please generate a prompt to be used by an AI image generator to generate an portrait image for this ${trimPlural(
+      generator.name.toLowerCase()
+    )} to be stored in the JSON property 'imageAIPrompt'. ${
+      generator.imagePromptExtraContext
+    }. `;
+  }
+
+  if (generator.basePromptExtraContext) {
+    prompt += generator.basePromptExtraContext;
+  }
+
+  logger.info("Built prompt", prompt);
+
+  return prompt;
+};

--- a/ui/src/api/generators.ts
+++ b/ui/src/api/generators.ts
@@ -16,6 +16,7 @@ export const getConjurer = (code: string) => {
 };
 
 export interface PostConjureRequest {
+  count: number;
   campaignId: number;
   customArgs?: CustomArg[];
 }
@@ -31,4 +32,8 @@ export const postConjure = (code: string, payload: PostConjureRequest) => {
 
 export const postQuickConjure = (code: string) => {
   return axios.post(`/generators/${code}/generate/quick`, {});
+};
+
+export const getConjurationRequest = (conjurationRequestId: number) => {
+  return axios.get(`/generators/requests/${conjurationRequestId}`);
 };

--- a/ui/src/components/Conjuration/ConjurationListItemView.vue
+++ b/ui/src/components/Conjuration/ConjurationListItemView.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
 import { CheckIcon, PlusIcon, XMarkIcon } from "@heroicons/vue/20/solid";
-import { addConjuration, deleteConjuration } from "@/api/conjurations.ts";
+import {
+  addConjuration,
+  Conjuration,
+  deleteConjuration,
+} from "@/api/conjurations.ts";
 import { useCurrentUserId } from "@/lib/hooks.ts";
 import { useRouter } from "vue-router";
 import { ref } from "vue";
 import { showSuccess } from "@/lib/notifications.ts";
 import DeleteModal from "@/components/Core/General/DeleteModal.vue";
 
-var props = defineProps({
-  conjuration: {
-    type: Object,
-    required: true,
-  },
-});
+const props = defineProps<{
+  conjuration: Conjuration | undefined;
+  skeleton?: boolean;
+}>();
 
 const emit = defineEmits(["add-conjuration", "remove-conjuration"]);
 
@@ -21,14 +23,6 @@ const currentUserId = useCurrentUserId();
 
 const isMyConjuration = (conjuration: any) =>
   conjuration.copies?.length || conjuration.userId === currentUserId.value;
-
-const backgroundImageInlineStyle = (imageUri: string | undefined): string => {
-  if (!imageUri) {
-    return "";
-  }
-
-  return `background-image: url("${imageUri}");`;
-};
 
 async function handleAddConjuration(conjurationId: number) {
   await addConjuration(conjurationId);
@@ -43,9 +37,9 @@ async function navigateToViewConjuration(conjurationId: number) {
 async function clickDeleteConjuration() {
   if (!props.conjuration || !isMyConjuration(props.conjuration)) return;
 
-  var conjurationId = props.conjuration.copies?.length
-    ? props.conjuration.copies[0].id
-    : props.conjuration.id;
+  var conjurationId = props.conjuration?.copies?.length
+    ? props.conjuration?.copies[0].id
+    : props.conjuration?.id;
   await deleteConjuration(conjurationId);
   showSuccess({ message: "Successfully removed conjuration" });
 
@@ -53,53 +47,99 @@ async function clickDeleteConjuration() {
   showDeleteModal.value = false;
 }
 
-var iconHover = ref(false);
+let iconHover = ref(false);
 const showDeleteModal = ref(false);
 </script>
 
 <template>
-  <div
-    class="relative flex h-[20rem] cursor-pointer flex-col justify-end rounded-lg bg-cover bg-top shadow-xl md:h-[30rem] 3xl:h-[40rem]"
-    :style="backgroundImageInlineStyle(conjuration.imageUri)"
-    @click="navigateToViewConjuration(conjuration.id)"
-  >
+  <div v-if="conjuration">
     <div
-      v-if="isMyConjuration(conjuration)"
-      class="absolute right-2 top-2 flex h-12 w-12 justify-center rounded-full bg-green-500 hover:bg-gray-500"
-      @mouseover="iconHover = true"
-      @mouseout="iconHover = false"
+      class="relative flex cursor-pointer flex-col justify-end rounded-lg shadow-xl"
+      @click="navigateToViewConjuration(conjuration.id)"
     >
-      <XMarkIcon
-        v-if="iconHover"
-        class="h-8 w-8 self-center text-white"
-        @click.stop="showDeleteModal = true"
-      />
-      <CheckIcon v-else class="h-8 w-8 self-center text-white" />
-    </div>
-    <div
-      v-else
-      class="absolute right-2 top-2 flex h-12 w-12 justify-center rounded-full bg-gray-800 hover:bg-gray-500"
-      @click.stop="handleAddConjuration(conjuration.id)"
-    >
-      <button class="self-center">
-        <PlusIcon class="h-8 w-8 text-white" />
-      </button>
-    </div>
-    <div class="flex justify-between rounded-b-lg bg-black/50 p-4">
-      <div>
-        <div class="text-xl font-bold">{{ conjuration.name }}</div>
-        <div class="flex flex-wrap">
+      <div
+        class="h-[20rem] md:h-[30rem] 3xl:h-[40rem] overflow-hidden rounded-t-xl"
+      >
+        <img
+          v-if="conjuration.imageUri"
+          :src="conjuration.imageUri"
+          :alt="conjuration.name"
+          class=""
+        />
+        <div v-else class="w-full flex justify-center h-full bg-gray-900/75">
           <div
-            v-for="tag of conjuration.tags"
-            :key="`${conjuration.id}-${tag}`"
-            class="mr-1 mt-1 rounded-xl bg-gray-800 px-2 py-1 text-xs"
+            class="self-center text-center text-[2rem] text-white animate-pulse"
           >
-            {{ tag }}
+            Conjuring image...
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="isMyConjuration(conjuration)"
+        class="absolute right-2 top-2 flex h-12 w-12 justify-center rounded-full bg-green-500 hover:bg-gray-500"
+        @mouseover="iconHover = true"
+        @mouseout="iconHover = false"
+      >
+        <XMarkIcon
+          v-if="iconHover"
+          class="h-8 w-8 self-center text-white"
+          @click.stop="showDeleteModal = true"
+        />
+        <CheckIcon v-else class="h-8 w-8 self-center text-white" />
+      </div>
+      <div
+        v-else
+        class="absolute right-2 top-2 flex h-12 w-12 justify-center rounded-full bg-gray-800 hover:bg-gray-500"
+        @click.stop="handleAddConjuration(conjuration.id)"
+      >
+        <button class="self-center">
+          <PlusIcon class="h-8 w-8 text-white" />
+        </button>
+      </div>
+
+      <div
+        class="flex w-full justify-between rounded-b-lg bg-black/50 p-4 h-[22rem]"
+      >
+        <div>
+          <div class="text-xl font-bold">{{ conjuration.name }}</div>
+          <div class="flex flex-wrap">
+            <div
+              v-for="tag of conjuration.tags"
+              :key="`${conjuration.id}-${tag}`"
+              class="mr-1 mt-1 rounded-xl bg-gray-800 px-2 py-1 text-xs"
+            >
+              {{ tag }}
+            </div>
+          </div>
+          <div class="mt-4 min-h-[12rem] max-h-[14rem] overflow-y-auto">
+            <template v-if="conjuration.conjurerCode === 'characters'">
+              <div class="self-center mb-2">Background</div>
+              <div class="text-gray-400 pr-6">
+                {{ conjuration.data.background }}
+              </div>
+            </template>
+            <template v-if="conjuration.conjurerCode === 'locations'">
+              <div class="self-center mb-2">History</div>
+              <div class="text-gray-400 pr-6">
+                {{ conjuration.data.history }}
+              </div>
+            </template>
           </div>
         </div>
       </div>
     </div>
   </div>
+  <div v-else-if="skeleton">
+    <div
+      class="w-full flex justify-center bg-gray-900/75 rounded-xl h-[42rem] md:h-[52rem] 3xl:h-[62rem]"
+    >
+      <div class="self-center text-center text-[3rem] text-white animate-pulse">
+        Conjuring...
+      </div>
+    </div>
+  </div>
+
   <DeleteModal v-model="showDeleteModal">
     <div class="text-center text-8xl">Wait!</div>
     <div class="mt-8 text-center text-3xl">

--- a/ui/src/components/Conjuration/ConjuringLoader.vue
+++ b/ui/src/components/Conjuration/ConjuringLoader.vue
@@ -99,7 +99,9 @@ const loadingSnippets = ref([
 </script>
 
 <template>
-  <div class="-mb-36 mt-12 animate-pulse text-center text-3xl text-purple-300">
+  <div
+    class="md:-mb-36 mt-12 animate-pulse text-center text-3xl text-purple-300"
+  >
     {{ loadingSnippet }}
   </div>
   <div

--- a/ui/src/components/Conjuration/ListConjurations.vue
+++ b/ui/src/components/Conjuration/ListConjurations.vue
@@ -98,7 +98,7 @@ function removeTag(tag: string) {
             ]"
             display-prop="name"
             value-prop="value"
-            class="mr-2 w-[20rem]"
+            class="mr-2 w-full md:w-[20rem]"
           />
         </div>
 
@@ -109,7 +109,7 @@ function removeTag(tag: string) {
             :options="conjurers"
             display-prop="name"
             value-prop="code"
-            class="mr-2 w-[20rem]"
+            class="mr-2 w-full md:w-[20rem]"
             multiple
             placeholder="Select conjuration types"
           />
@@ -117,7 +117,7 @@ function removeTag(tag: string) {
 
         <div class="mt-2 md:mt-0">
           <div class="mb-1 text-gray-300">Tags</div>
-          <div class="w-[20rem]">
+          <div class="w-full md:w-[20rem]">
             <Autocomplete
               v-model="conjurationsQuery.tags"
               :options="tags.map((t) => ({ value: t }))"

--- a/ui/src/components/Navigation/NavBar.vue
+++ b/ui/src/components/Navigation/NavBar.vue
@@ -17,7 +17,7 @@ async function logout() {
   <div class="bg flex flex-col justify-between p-4">
     <div>
       <div class="flex justify-between">
-        <img src="/images/logo-horizontal.svg" class="h-20 w-auto" />
+        <img src="/images/logo-horizontal.svg" class="h-12 w-auto" />
         <div
           class="self-center text-purple-400 md:mb-6 md:hidden"
           @click="showPanel = true"
@@ -55,7 +55,7 @@ async function logout() {
 
           <div class="flex h-full flex-col justify-between">
             <div>
-              <NavbarContent />
+              <NavbarContent @nav-item-selected="showPanel = false" />
             </div>
 
             <div class="">

--- a/ui/src/components/Navigation/NavbarContent.vue
+++ b/ui/src/components/Navigation/NavbarContent.vue
@@ -36,6 +36,8 @@ const navItems = [
   },
 ];
 
+const emit = defineEmits(["nav-item-selected"]);
+
 const { selectedCampaign, selectedCampaignId, campaigns } =
   storeToRefs(campaignStore);
 
@@ -166,6 +168,7 @@ async function navigateToCreateCampaign() {
           : '',
       ]"
       :to="navItem.path"
+      @click="emit('nav-item-selected')"
     >
       {{ navItem.name }}
     </router-link>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -50,3 +50,26 @@ input::-webkit-inner-spin-button {
 input[type="number"] {
   -moz-appearance: textfield;
 }
+
+/* width */
+::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+/* Track */
+::-webkit-scrollbar-track {}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #4A4A4A;
+  border-radius: 8px;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: #222222;
+  border: 1px solid #000000;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Created new conjuration requests db table that will eventually allow users to backtrace and see all conjuration requests they've made. This table also serves as a foothold to allow us to wait for conjurations against that request to be generated. Currently this waiting is done via polling every 5 seconds, but we should switch to websockets eventually. Made a number of UI improvements to support these changes as well.