### PR TITLE
Initial campaign modal overflow fix

### DIFF
--- a/test/codecept.conf.ts
+++ b/test/codecept.conf.ts
@@ -1,4 +1,8 @@
-import { setHeadlessWhen, setCommonPlugins, setWindowSize } from '@codeceptjs/configure';
+import {
+  setHeadlessWhen,
+  setCommonPlugins,
+  setWindowSize
+} from '@codeceptjs/configure';
 setHeadlessWhen(process.env.HEADLESS);
 setWindowSize(1920, 1080);
 
@@ -16,7 +20,8 @@ export const config: CodeceptJS.MainConfig = {
     }
   },
   include: {
-    I: './steps_file'
+    I: './steps_file',
+    loginPage: "./pages/login.ts",
   },
   name: 'test'
 }

--- a/test/pages/login.ts
+++ b/test/pages/login.ts
@@ -1,0 +1,17 @@
+const { I } = inject();
+
+export = {
+  fields: {
+    email: 'input[name="email"]',
+  },
+  loginButton: 'Login',
+
+  login(email: string) {
+    I.amOnPage('/');
+    I.see('Welcome to MythWeaver');
+    I.click(this.fields.email);
+    I.type(email);
+    I.click(this.loginButton);
+    I.see("We've emailed you a one-time login link");
+  },
+};

--- a/test/steps.d.ts
+++ b/test/steps.d.ts
@@ -2,7 +2,7 @@
 type steps_file = typeof import('./steps_file');
 
 declare namespace CodeceptJS {
-  interface SupportObject { I: I, current: any }
+  interface SupportObject { I: I, current: any, loginPage: any }
   interface Methods extends Playwright {}
   interface I extends ReturnType<steps_file> {}
   namespace Translation {

--- a/test/ui/register_early_access_test.ts
+++ b/test/ui/register_early_access_test.ts
@@ -1,8 +1,8 @@
-Feature('Register Early Access');
+Feature('Magic Link');
 
-Scenario('Can get to mailing list page', ({ I }) => {
-  I.amOnPage('/');
-  I.click('#early-access-link')
-  I.click('#mailing-list-link')
-  I.amOnPage('mythweaver.co/#mailing')
+Scenario('Send myself a magic link with valid e-mail', ({ I, loginPage }) => {
+  loginPage.login('Andrew.S.Lobdell@gmail.com');
+  I.click('Back to login');
+  I.see('Welcome to MythWeaver');
 });
+

--- a/ui/src/components/Login/LoginContent.vue
+++ b/ui/src/components/Login/LoginContent.vue
@@ -54,6 +54,7 @@ async function login() {
     <input
       v-model="email"
       autofocus
+      name="email"
       class="text-2xl mt-2 py-4 w-full rounded-xl border bg-black px-4 text-left text-white"
       :class="{
         'border-red-500': !isEmailValid && triedToSubmit,

--- a/ui/src/components/ModalAlternate.vue
+++ b/ui/src/components/ModalAlternate.vue
@@ -16,7 +16,7 @@
         class="flex min-h-full flex-col items-end justify-center p-4 text-center sm:items-center sm:p-0"
       >
         <div
-          class="relative mb-4 transform overflow-hidden rounded-lg text-left shadow-xl transition-all"
+          class="relative mb-4 transform overflow-visible rounded-lg text-left shadow-xl transition-all"
           @click="$event.stopPropagation()"
         >
           <slot></slot>


### PR DESCRIPTION
Ignore that I forgot to scrub out my testing changes please. Allows 
![image](https://github.com/Bitmischief/mythweaver/assets/11340899/dddcd56e-3579-46f0-a73e-0aeddee9f7c4)
Rather than cutting of like,
![image](https://github.com/Bitmischief/mythweaver/assets/11340899/cef55b87-0d8d-4d6c-921c-d570c074d870)
