### PR TITLE
task/prevent viewing private conjurations

### DIFF
--- a/api/controllers/conjurations.ts
+++ b/api/controllers/conjurations.ts
@@ -148,7 +148,11 @@ export default class ConjurationController {
       },
     });
 
-    if (!conjuration || (conjuration.visibility === ConjurationVisibility.PRIVATE && conjuration.userId !== userId)) {
+    if (
+      !conjuration ||
+      (conjuration.visibility === ConjurationVisibility.PRIVATE &&
+        conjuration.userId !== userId)
+    ) {
       throw new AppError({
         description: 'Conjuration not found.',
         httpCode: HttpCode.NOT_FOUND,

--- a/api/controllers/conjurations.ts
+++ b/api/controllers/conjurations.ts
@@ -148,7 +148,7 @@ export default class ConjurationController {
       },
     });
 
-    if (!conjuration) {
+    if (!conjuration || (conjuration.visibility === ConjurationVisibility.PRIVATE && conjuration.userId !== userId)) {
       throw new AppError({
         description: 'Conjuration not found.',
         httpCode: HttpCode.NOT_FOUND,

--- a/ui/src/components/Conjuration/ViewConjuration.vue
+++ b/ui/src/components/Conjuration/ViewConjuration.vue
@@ -61,7 +61,9 @@ async function loadConjuration() {
       conjuration.value = response.data;
 
       if (conjuration.value?.copies?.length) {
-        await router.push(`/conjurations/view/${conjuration.value.copies[0].id}`);
+        await router.push(
+          `/conjurations/view/${conjuration.value.copies[0].id}`,
+        );
         await loadConjuration();
       }
     }
@@ -70,7 +72,9 @@ async function loadConjuration() {
       showInfo({ message: 'Conjuration not found.' });
       await router.push('/conjurations');
     } else {
-      showError({ message: 'We were unable to fetch this conjuration. Please try again.' });
+      showError({
+        message: 'We were unable to fetch this conjuration. Please try again.',
+      });
     }
   }
 }

--- a/ui/src/components/Conjuration/ViewConjuration.vue
+++ b/ui/src/components/Conjuration/ViewConjuration.vue
@@ -17,7 +17,7 @@ import {
 } from '@heroicons/vue/24/solid';
 import { BookmarkSquareIcon } from '@heroicons/vue/24/outline';
 import { useCurrentUserId, useQuickConjure } from '@/lib/hooks.ts';
-import { showSuccess } from '@/lib/notifications.ts';
+import { showSuccess, showError, showInfo } from '@/lib/notifications.ts';
 
 const route = useRoute();
 const router = useRouter();
@@ -55,13 +55,22 @@ watch(conjurationId, async () => {
 });
 
 async function loadConjuration() {
-  if (conjurationId.value) {
-    const response = await getConjuration(conjurationId.value);
-    conjuration.value = response.data;
+  try {
+    if (conjurationId.value) {
+      const response = await getConjuration(conjurationId.value);
+      conjuration.value = response.data;
 
-    if (conjuration.value?.copies?.length) {
-      await router.push(`/conjurations/view/${conjuration.value.copies[0].id}`);
-      await loadConjuration();
+      if (conjuration.value?.copies?.length) {
+        await router.push(`/conjurations/view/${conjuration.value.copies[0].id}`);
+        await loadConjuration();
+      }
+    }
+  } catch (e: any) {
+    if (e.response.status === 404) {
+      showInfo({ message: 'Conjuration not found.' });
+      await router.push('/conjurations');
+    } else {
+      showError({ message: 'We were unable to fetch this conjuration. Please try again.' });
     }
   }
 }


### PR DESCRIPTION
If a user requests a conjuration that is set to private and belongs to another user the API will now return a 404 and the UI will show a message and redirect the user back to the conjurations list