### PR TITLE
cleanup and improvements

### DIFF
--- a/api/controllers/auth.ts
+++ b/api/controllers/auth.ts
@@ -306,7 +306,7 @@ export default class AuthController {
         'Initial credits for signup',
       );
 
-      await prisma.campaign.create({
+      const campaign = await prisma.campaign.create({
         data: {
           name: 'My Campaign',
           description: '',
@@ -319,6 +319,14 @@ export default class AuthController {
               joinedAt: new Date(),
             },
           },
+        },
+      });
+
+      await prisma.collections.create({
+        data: {
+          campaignId: campaign.id,
+          name: campaign.name,
+          userId: user.id,
         },
       });
 

--- a/api/controllers/campaigns.ts
+++ b/api/controllers/campaigns.ts
@@ -653,7 +653,11 @@ export default class CampaignController {
     const campaign = await prisma.campaign.findUnique({
       where: {
         id: campaignId,
-        userId: userId,
+        members: {
+          some: {
+            userId,
+          },
+        },
       },
     });
 
@@ -700,7 +704,7 @@ export default class CampaignController {
   }
 
   @Security('jwt')
-  @OperationId('postCampaignConjuration')
+  @OperationId('deleteCampaignConjuration')
   @Delete('/:campaignId/conjurations/:conjurationId')
   public async deleteCampaignConjuration(
     @Inject() userId: number,
@@ -714,7 +718,11 @@ export default class CampaignController {
     const campaign = await prisma.campaign.findUnique({
       where: {
         id: campaignId,
-        userId: userId,
+        members: {
+          some: {
+            userId,
+          },
+        },
       },
     });
 

--- a/api/controllers/collections.ts
+++ b/api/controllers/collections.ts
@@ -51,6 +51,7 @@ export default class CollectionController {
     @Inject() logger: MythWeaverLogger,
     @Query() parentId?: number,
     @Query() campaignId?: number,
+    @Query() conjurationId?: number,
   ) {
     logger.info('Getting collections', { userId, parentId });
 
@@ -132,6 +133,16 @@ export default class CollectionController {
       });
     }
 
+    let conjurationCollections: any[] = [];
+    if (conjurationId) {
+      conjurationCollections = await prisma.collectionConjuration.findMany({
+        where: {
+          conjurationId: conjurationId,
+        },
+        distinct: ['collectionId'],
+      });
+    }
+
     return {
       collections: collections.map((col: any) => {
         const children = collectionTree.filter(
@@ -146,6 +157,9 @@ export default class CollectionController {
           ...col,
           placeholders: childConjurations.map(
             (cc: any) => cc.conjuration.images[0].uri,
+          ),
+          containsConjuration: conjurationCollections.some(
+            (cc: any) => cc.collectionId === col.id,
           ),
         };
       }),

--- a/api/controllers/collections.ts
+++ b/api/controllers/collections.ts
@@ -534,6 +534,17 @@ export default class CollectionController {
       });
     }
 
+    if (
+      !collection.parentCollectionId &&
+      !parentCollection.parentCollectionId
+    ) {
+      throw new AppError({
+        description:
+          'Cannot move root campaign collection into another campaign collection.',
+        httpCode: HttpCode.BAD_REQUEST,
+      });
+    }
+
     logger.info('Posting move collection', {
       userId,
       postMoveCollectionRequest,

--- a/api/controllers/images.ts
+++ b/api/controllers/images.ts
@@ -268,11 +268,12 @@ export default class ImageController {
       },
     });
 
-    await sendWebsocketMessage(
-      userId,
-      WebSocketEvent.PrimaryImageSet,
-      updatedImages,
-    );
+    await sendWebsocketMessage(userId, WebSocketEvent.PrimaryImageSet, {
+      images: updatedImages,
+      context: {
+        conjurationId: image.conjurationId,
+      },
+    });
   }
 
   @Security('jwt')

--- a/api/lib/authMiddleware.ts
+++ b/api/lib/authMiddleware.ts
@@ -112,7 +112,7 @@ const createNewUser = async (res: Response, email: string, logger: any) => {
     'Initial credits for signup',
   );
 
-  await prisma.campaign.create({
+  const campaign = await prisma.campaign.create({
     data: {
       name: 'My Campaign',
       description: '',
@@ -125,6 +125,14 @@ const createNewUser = async (res: Response, email: string, logger: any) => {
           joinedAt: new Date(),
         },
       },
+    },
+  });
+
+  await prisma.collections.create({
+    data: {
+      campaignId: campaign.id,
+      name: campaign.name,
+      userId: user.id,
     },
   });
 

--- a/api/routes/collections.ts
+++ b/api/routes/collections.ts
@@ -13,6 +13,7 @@ const router = express.Router();
 const getCollectionsSchema = z.object({
   parentId: z.coerce.number().optional(),
   campaignId: z.coerce.number().optional(),
+  conjurationId: z.coerce.number().optional(),
 });
 
 router.get('/', [
@@ -31,6 +32,7 @@ router.get('/', [
       useLogger(),
       req.query.parentId as unknown as number,
       req.query.campaignId as unknown as number,
+      req.query.conjurationId as unknown as number,
     );
 
     return res.status(200).send(response);

--- a/api/routes/relationships.ts
+++ b/api/routes/relationships.ts
@@ -162,7 +162,7 @@ router.patch('/:relationshipId', [
 ]);
 
 const getRelationshipGraphSchema = z.object({
-  depthLimit: z.coerce.number().min(1).max(10).default(5).optional(),
+  campaignId: z.coerce.number().optional(),
 });
 
 router.get('/graph', [
@@ -175,13 +175,13 @@ router.get('/graph', [
   async (req: Request, res: Response) => {
     const controller = new RelationshipController();
 
-    const { depthLimit = 10 } = req.query;
+    const { campaignId = undefined } = req.query;
 
     const response = await controller.getRelationshipGraph(
       res.locals.auth.userId,
       res.locals.trackingInfo,
       useLogger(),
-      depthLimit as unknown as number,
+      campaignId as unknown as number,
     );
 
     return res.status(200).send(response);

--- a/api/services/images/imageGeneration.ts
+++ b/api/services/images/imageGeneration.ts
@@ -137,11 +137,12 @@ const generateSingleImage = async (
     },
   });
 
-  await sendWebsocketMessage(
-    request.userId,
-    WebSocketEvent.ImageCreated,
-    updatedImage,
-  );
+  await sendWebsocketMessage(request.userId, WebSocketEvent.ImageCreated, {
+    image: updatedImage,
+    context: {
+      ...request.linking,
+    },
+  });
 
   return updatedImage;
 };

--- a/api/services/images/upscalingService.ts
+++ b/api/services/images/upscalingService.ts
@@ -73,7 +73,11 @@ export const upscaleImage = async (userId: number, imageId: number) => {
     updatedImage,
   );
 
-  await sendWebsocketMessage(userId, WebSocketEvent.ImageUpscalingDone, {});
+  await sendWebsocketMessage(
+    userId,
+    WebSocketEvent.ImageUpscalingDone,
+    updatedImage,
+  );
 
   await modifyImageCreditCount(
     user.id,

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -206,7 +206,7 @@ async function finishOnboarding(sourceInfo: {
         v-if="!!authStore.user"
         class="hidden md:flex border-b border-zinc-900"
       >
-        <div class="w-full bg-surface-2 z-10 h-[4rem] flex">
+        <div class="w-full bg-surface-2 z-20 h-[4rem] flex">
           <NavBarHeader />
         </div>
       </div>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,17 +7,12 @@ import { onMounted, onBeforeMount, onUpdated, ref, watch } from 'vue';
 import NavBarHeader from '@/components/Navigation/NavBarHeader.vue';
 import ModalAlternate from '@/components/ModalAlternate.vue';
 import LightboxRoot from '@/components/LightboxRoot.vue';
-import CustomizeConjurationImage from '@/components/Conjuration/ViewConjuration/CustomizeConjurationImage.vue';
 import { useIntercom } from '@homebaseai/vue3-intercom';
 import Loader from './components/Core/Loader.vue';
 import { ServerEvent } from '@/lib/serverEvents.ts';
 import { showSuccess } from '@/lib/notifications.ts';
 import { useCurrentUserPlan, useWebsocketChannel } from '@/lib/hooks.ts';
-import {
-  useLDClient,
-  useLDFlag,
-  useLDReady,
-} from 'launchdarkly-vue-client-sdk';
+import { useLDClient, useLDReady } from 'launchdarkly-vue-client-sdk';
 import UpgradeContainer from '@/components/Core/Billing/UpgradeContainer.vue';
 import mixpanel from 'mixpanel-browser';
 import { getRedeemPreOrderUrl } from '@/api/billing.ts';
@@ -48,7 +43,6 @@ const route = useRoute();
 const showPreorderRedemptionModal = ref(false);
 const showUpgradeModal = ref(false);
 const { isLoading, isAuthenticated } = useAuth0();
-const conjureV2 = useLDFlag('conjure-v2');
 const showUserSourceModal = ref(false);
 
 onBeforeMount(async () => {
@@ -284,18 +278,10 @@ async function finishOnboarding(sourceInfo: {
       class="relative pt-2 md:m-6 md:p-6 md:px-12 bg-surface-2 rounded-[20px] min-w-[70vw] max-w-[90vw] text-white mb-12"
     >
       <ConjureImage
-        v-if="conjureV2"
         :image="customizeImageArgs?.image"
         :linking="customizeImageArgs?.linking"
         :history-mode="customizeImageArgs?.historyMode"
         :show-image-credits="customizeImageArgs?.showImageCredits"
-        in-modal
-        @cancel="showCustomizeImageModal = false"
-      />
-      <CustomizeConjurationImage
-        v-else
-        :image="customizeImageArgs?.image"
-        :linking="customizeImageArgs?.linking"
         in-modal
         @cancel="showCustomizeImageModal = false"
       />

--- a/ui/src/api/collections.ts
+++ b/ui/src/api/collections.ts
@@ -21,11 +21,12 @@ export interface PostMoveCollectionSchema {
   parentCollectionId: number;
 }
 
-export const getCollections = (parentId?: number, campaignId?: number) => {
+export const getCollections = (parentId?: number, campaignId?: number, conjurationId?: number) => {
   return axios.get(`/collections`, {
     params: {
       parentId,
       campaignId,
+      conjurationId,
     },
   });
 };

--- a/ui/src/api/relationships.ts
+++ b/ui/src/api/relationships.ts
@@ -58,6 +58,10 @@ export const patchConjurationRelationship = (
   return axios.patch(`/relationships/${relationshipId}`, patchConjurationRelationshipRequest);
 };
 
-export const getRelationshipGraph = () => {
-  return axios.get(`/relationships/graph`);
+export const getRelationshipGraph = (campaignId?: number) => {
+  return axios.get(`/relationships/graph`, {
+    params: {
+      campaignId,
+    },
+  });
 };

--- a/ui/src/components/Characters/NewCharacter.vue
+++ b/ui/src/components/Characters/NewCharacter.vue
@@ -32,9 +32,9 @@ onMounted(async () => {
   channel.bind(ServerEvent.PrimaryImageSet, primaryImageSetHandler);
 });
 
-function primaryImageSetHandler(data: any[]) {
+function primaryImageSetHandler(data: any) {
   setTimeout(() => {
-    character.value.images = data;
+    character.value.images = data.images;
     step.value++;
   }, 50);
 }

--- a/ui/src/components/Collections/Collection.vue
+++ b/ui/src/components/Collections/Collection.vue
@@ -5,7 +5,7 @@ import {
   patchCollection,
   postMoveCollection,
 } from '@/api/collections.ts';
-import { showError, showSuccess } from '@/lib/notifications.ts';
+import { showError, showSuccess, showInfo } from '@/lib/notifications.ts';
 import { useDrag, useDrop } from 'vue3-dnd';
 import Menu from '@/components/Core/General/Menu.vue';
 import { MenuButton, MenuItems, MenuItem } from '@headlessui/vue';
@@ -50,7 +50,13 @@ const [collect, drag] = useDrag(() => ({
       dropResult?.type === 'Collection' &&
       item.id !== dropResult.id
     ) {
-      await postMoveCollection(item.id, { parentCollectionId: dropResult.id });
+      try {
+        await postMoveCollection(item.id, {
+          parentCollectionId: dropResult.id,
+        });
+      } catch (e: any) {
+        showInfo({ message: e.response.data.message });
+      }
     }
   },
   collect: (monitor) => ({

--- a/ui/src/components/Collections/CollectionMove.vue
+++ b/ui/src/components/Collections/CollectionMove.vue
@@ -50,6 +50,7 @@ const moveCollection = async () => {
         v-model="selectedMoveLocation"
         :collection-id="collection.id"
         :parent-id="undefined"
+        :conjuration-id="undefined"
       />
     </div>
     <div class="flex gap-4 mt-4">

--- a/ui/src/components/Collections/CollectionMoveTree.vue
+++ b/ui/src/components/Collections/CollectionMoveTree.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   modelValue: any;
   collectionId: number | undefined;
   parentId: number | undefined;
+  conjurationId: number | undefined;
 }>();
 
 const emit = defineEmits(['update:modelValue']);
@@ -36,7 +37,11 @@ onMounted(async () => {
 const fetchCollections = async () => {
   loading.value = true;
   try {
-    const response = await getCollections(props.parentId);
+    const response = await getCollections(
+      props.parentId,
+      undefined,
+      props.conjurationId,
+    );
     return (
       response.data?.collections?.filter(
         (c: any) => c.id !== props.collectionId,
@@ -120,8 +125,12 @@ const addCollection = async () => {
               </div>
             </div>
             <div
-              v-if="value?.id === col.id"
-              class="text-violet-500 self-center"
+              v-if="value?.id === col.id || col.containsConjuration"
+              class="self-center"
+              :class="{
+                'text-violet-500': value?.id === col.id,
+                'text-neutral-500': col.containsConjuration,
+              }"
             >
               <CheckCircleIcon class="h-6 w-6 self-center" />
             </div>
@@ -135,6 +144,7 @@ const addCollection = async () => {
             v-model="value"
             :collection-id="props.collectionId"
             :parent-id="col.id"
+            :conjuration-id="props.conjurationId"
           />
         </div>
       </div>

--- a/ui/src/components/Collections/ConjurationMove.vue
+++ b/ui/src/components/Collections/ConjurationMove.vue
@@ -66,10 +66,15 @@ const moveConjuration = async () => {
         v-model="selectedMoveLocation"
         :collection-id="undefined"
         :parent-id="undefined"
+        :conjuration-id="conjuration.id"
       />
     </div>
     <div
-      v-if="selectedMoveLocation && selectedMoveLocation.id === collectionId"
+      v-if="
+        selectedMoveLocation &&
+        (selectedMoveLocation.containsConjuration ||
+          selectedMoveLocation.id === collectionId)
+      "
       class="text-sm text-neutral-500 mx-2 mt-4"
     >
       {{ conjuration.name }} is already in this collection.
@@ -87,7 +92,9 @@ const moveConjuration = async () => {
       <button
         class="button-gradient basis-1/2"
         :disabled="
-          !selectedMoveLocation || selectedMoveLocation.id === collectionId
+          !selectedMoveLocation ||
+          selectedMoveLocation.containsConjuration ||
+          selectedMoveLocation.id === collectionId
         "
         @click="moveConjuration"
       >

--- a/ui/src/components/Conjuration/ConjurationListItemView.vue
+++ b/ui/src/components/Conjuration/ConjurationListItemView.vue
@@ -192,15 +192,6 @@ const conjurationName = computed(() => {
           class="rounded-[16px] aspect-square pointer-events-none"
         />
         <div
-          class="absolute flex justify-center items-center rounded-full bg-white/50 text-black text-xs font-bold"
-          :class="{
-            'left-1 top-1 h-4 px-2': condensedView,
-            'left-2 top-2 h-6 px-4': !condensedView,
-          }"
-        >
-          {{ conjurationType(conjuration) }}
-        </div>
-        <div
           v-if="showBookmarkIcon"
           class="absolute text-white/75 group/bookmark"
           :class="{
@@ -261,6 +252,11 @@ const conjurationName = computed(() => {
             v-if="hideTags !== true"
             class="flex flex-wrap max-h-[3.5em] overflow-hidden"
           >
+            <div class="tag bg-white/75 text-black flex group group-hover:pr-2">
+              <span class="self-center">
+                {{ conjurationType(conjuration) }}
+              </span>
+            </div>
             <div
               v-for="(tag, i) in conjuration.tags"
               :key="`${i}_${conjuration.id}_tag`"

--- a/ui/src/components/Conjuration/ListConjurations.vue
+++ b/ui/src/components/Conjuration/ListConjurations.vue
@@ -47,6 +47,7 @@ const images = [
 const currentUserPlan = useCurrentUserPlan();
 
 const pagingDone = ref(false);
+const pageLoading = ref(false);
 const conjurations = ref<Conjuration[]>([]);
 const showFilters = ref(false);
 const loading = ref(false);
@@ -160,6 +161,8 @@ const pageConjurations = debounce(() => {
 async function loadConjurations(append = false) {
   if (pagingDone.value || currentUserPlan.value === BillingPlan.Free) return;
 
+  pageLoading.value = true;
+
   const conjurationsResponse = await getConjurations({
     ...conjurationsQuery.value,
   });
@@ -173,6 +176,8 @@ async function loadConjurations(append = false) {
   if (conjurationsResponse.data.data.length === 0) {
     pagingDone.value = true;
   }
+
+  pageLoading.value = false;
 }
 
 function handleFiltersUpdated(filters: any) {
@@ -309,6 +314,27 @@ const clearFilters = () => {
 
   <div v-if="currentUserPlan !== BillingPlan.Free">
     <div
+      v-if="!conjurations.length && loading"
+      class="grid place-items-stretch gap-2 md:gap-5 animate-pulse"
+      :class="{
+        'grid-cols-1 md:grid-cols-2 xl:grid-cols-3': viewType === 'list',
+        'grid-cols-2 md:grid-cols-3 lg:grid-cols-4': viewType === 'grid',
+      }"
+    >
+      <div
+        v-for="n in 12"
+        :key="`sk_${n}`"
+        class="rounded-[24px] bg-surface-2 p-2"
+      >
+        <div class="w-full rounded-[18px] aspect-square bg-surface-3"></div>
+        <div class="w-full rounded-full bg-surface-3 mt-2 h-[1.5em]"></div>
+        <div class="flex gap-2">
+          <div class="rounded-full bg-surface-3 mt-2 h-[1.5em] w-[20%]"></div>
+          <div class="rounded-full bg-surface-3 mt-2 h-[1.5em] w-[20%]"></div>
+        </div>
+      </div>
+    </div>
+    <div
       v-if="!conjurations.length && conjurationsMineQuery.saved && !loading"
       class="flex justify-center h-full"
     >
@@ -350,7 +376,11 @@ const clearFilters = () => {
         @remove-conjuration="handleConjurationChange"
       />
     </div>
-
+    <div v-if="pageLoading" class="my-12 pb-12 w-full">
+      <div class="text-center text-xl text-gray-500 divider animate-pulse">
+        Loading More...
+      </div>
+    </div>
     <div v-if="conjurations.length && pagingDone" class="my-12 pb-12 w-full">
       <div class="text-center text-xl text-gray-500 divider">
         No more conjurations to show!

--- a/ui/src/components/Conjuration/ViewConjuration.vue
+++ b/ui/src/components/Conjuration/ViewConjuration.vue
@@ -470,7 +470,10 @@ async function addToCampaign() {
       >
         <div class="flex gap-6 justify-between">
           <div class="text-lg self-center">Change Conjuration Type</div>
-          <div class="self-center" @click="showConvertConjurationType = false">
+          <div
+            class="self-center cursor-pointer"
+            @click="showConvertConjurationType = false"
+          >
             <XCircleIcon class="h-6 w-6" />
           </div>
         </div>

--- a/ui/src/components/Conjuration/ViewConjuration/CustomizeConjuration.vue
+++ b/ui/src/components/Conjuration/ViewConjuration/CustomizeConjuration.vue
@@ -97,16 +97,20 @@ function imageCreatedHandler(image: any) {
   }
 }
 
-function primaryImageSetHandler(data: any[]) {
-  editableConjuration.value.images = data;
-  imageKey.value++;
-  showSuccess({ message: 'Image saved' });
+function primaryImageSetHandler(data: any) {
+  if (data.context?.conjurationId === editableConjuration.value.id) {
+    editableConjuration.value.images = data.images;
+    imageKey.value++;
+    showSuccess({ message: 'Image saved' });
+  }
 }
 
 function imageUpscaledHandler(data: any) {
-  editableConjuration.value.images = [{ ...data }];
-  imageKey.value++;
-  showSuccess({ message: 'Image upscaled' });
+  if (data.id === primaryImage.value?.id) {
+    editableConjuration.value.images = [{ ...data }];
+    imageKey.value++;
+    showSuccess({ message: 'Image upscaled' });
+  }
 }
 
 function imageFilteredHandler() {
@@ -339,6 +343,9 @@ async function viewGraph() {
         <div class="mt-5 px-1 flex flex-wrap">
           <div class="text-xs text-neutral-400">TAGS</div>
           <div class="flex flex-wrap">
+            <div class="tag bg-white/75 text-black flex group group-hover:pr-2">
+              <span class="self-center">{{ conjurationType }}</span>
+            </div>
             <div
               v-for="tag of editableConjuration.tags"
               :key="`${editableConjuration.id}-${tag}`"

--- a/ui/src/components/Conjuration/ViewConjuration/CustomizeConjurationImage.vue
+++ b/ui/src/components/Conjuration/ViewConjuration/CustomizeConjurationImage.vue
@@ -112,21 +112,25 @@ onMounted(async () => {
 });
 
 function imageCreatedHandler(data: any) {
-  images.value.push(data);
-  conjuring.value = false;
-  loading.value = false;
-  if (selectedImg.value === null) {
-    selectedImg.value = data;
+  if (data.context?.conjurationId === props.linking?.conjurationId) {
+    images.value.push(data);
+    conjuring.value = false;
+    loading.value = false;
+    if (selectedImg.value === null) {
+      selectedImg.value = data;
+    }
   }
 }
 
-function imageFilteredHandler() {
-  showError({
-    message:
-      'The generated image was filtered out by our content moderation system. Please try again.',
-  });
-  imageFiltered.value = true;
-  conjuring.value = false;
+function imageFilteredHandler(data: any) {
+  if (data.context?.conjurationId === props.linking?.conjurationId) {
+    showError({
+      message:
+        'The generated image was filtered out by our content moderation system. Please try again.',
+    });
+    imageFiltered.value = true;
+    conjuring.value = false;
+  }
 }
 
 onUnmounted(() => {
@@ -158,25 +162,31 @@ function imagePromptRephrasedHandler(prompt: string) {
 }
 
 function imageErrorHandler(data: any) {
-  showError({
-    message: data.message,
-  });
-  imageError.value = true;
-  conjuring.value = false;
-  upscaling.value = false;
-}
-
-function imageUpscaledHandler(data: any) {
-  selectedImg.value = data;
-  upscaling.value = false;
-  if (props.inModal) {
-    eventBus.$emit('toggle-customize-image-modal');
+  if (data.context?.conjurationId === props.linking?.conjurationId) {
+    showError({
+      message: data.message,
+    });
+    imageError.value = true;
+    conjuring.value = false;
+    upscaling.value = false;
   }
 }
 
-function imageUpscalingDoneHandler() {
-  loading.value = true;
-  showSuccess({ message: 'Image successfully upscaled!' });
+function imageUpscaledHandler(data: any) {
+  if (data.id === props.image.id) {
+    selectedImg.value = data;
+    upscaling.value = false;
+    if (props.inModal) {
+      eventBus.$emit('toggle-customize-image-modal');
+    }
+  }
+}
+
+function imageUpscalingDoneHandler(data: any) {
+  if (data.id === props.image.id) {
+    loading.value = true;
+    showSuccess({ message: 'Image successfully upscaled!' });
+  }
 }
 
 async function conjure() {

--- a/ui/src/components/Conjure/CreateConjurationImage.vue
+++ b/ui/src/components/Conjure/CreateConjurationImage.vue
@@ -27,10 +27,12 @@ onMounted(() => {
   channel.bind(ServerEvent.PrimaryImageSet, primaryImageSetHandler);
 });
 
-async function primaryImageSetHandler() {
-  showSuccess({ message: 'Successfully saved conjuration image!' });
-  await saveConjuration(conjuration.value.id);
-  await viewConjuration();
+async function primaryImageSetHandler(data: any) {
+  if (data.context?.conjurationId === conjuration.value.id) {
+    showSuccess({ message: 'Successfully saved conjuration image!' });
+    await saveConjuration(conjuration.value.id);
+    await viewConjuration();
+  }
 }
 
 onUnmounted(() => {

--- a/ui/src/components/Conjure/DescribeConjuration.vue
+++ b/ui/src/components/Conjure/DescribeConjuration.vue
@@ -87,16 +87,20 @@ function handleBeginConjuring(data: { conjurationRequestId: number }) {
 }
 
 function conjurationCreatedHandler(data: any) {
-  value.value = data;
-  emit('next');
-  generating.value = false;
+  if (conjurationRequestId.value === data.conjurationRequestId) {
+    value.value = data;
+    emit('next');
+    generating.value = false;
+  }
 }
 
-function conjurationErrorHandler() {
-  generating.value = false;
-  showError({
-    message: `There was a server error creating your ${props.generator.name}. Please try again, or reach out to support if the problem persists.`,
-  });
+function conjurationErrorHandler(data: any) {
+  if (conjurationRequestId.value === data.conjurationRequestId) {
+    generating.value = false;
+    showError({
+      message: `There was a server error creating your ${props.generator.name}. Please try again, or reach out to support if the problem persists.`,
+    });
+  }
 }
 
 onUnmounted(() => {

--- a/ui/src/components/Conjure/GeneratorSelect.vue
+++ b/ui/src/components/Conjure/GeneratorSelect.vue
@@ -68,6 +68,7 @@ const proOnly = (gen: Conjurer) => {
         'relative proOnly': proOnly(gens),
         'relative group/experimental': !proOnly(gens) && gens.experimental,
       }"
+      @mouseover="!proOnly(gens) ? (value = gens) : null"
       @click="
         !proOnly(gens)
           ? (value = gens)

--- a/ui/src/components/Core/Loader.vue
+++ b/ui/src/components/Core/Loader.vue
@@ -18,6 +18,7 @@
   overflow: hidden;
   z-index: 5;
 }
+
 .loader:before,
 .loader:after {
   content: '';
@@ -29,6 +30,7 @@
   background-color: rgba(#050712, 0.4);
   animation: wave 5s linear infinite;
 }
+
 .loader:before {
   width: 100%;
   height: 100%;

--- a/ui/src/components/Core/UserSignupSource.vue
+++ b/ui/src/components/Core/UserSignupSource.vue
@@ -49,6 +49,10 @@ const influencers = ref([
     name: 'Vatara',
   },
   {
+    id: 'nerdieststepdad',
+    name: 'Nerdiest Step Dad',
+  },
+  {
     id: 'other',
     name: 'Other',
   },

--- a/ui/src/components/Images/CustomizableImage.vue
+++ b/ui/src/components/Images/CustomizableImage.vue
@@ -118,10 +118,6 @@ const alreadyUpscaled = computed(() => {
 <template>
   <div class="relative">
     <div class="relative">
-      <div v-if="image.uri" class="image-badge">
-        {{ type }}
-      </div>
-
       <div
         v-if="image.imageModel?.description"
         class="absolute flex bottom-2 right-2 cursor-pointer bg-neutral-500/50 rounded-[8px]"

--- a/ui/src/components/Navigation/NavBarHeader.vue
+++ b/ui/src/components/Navigation/NavBarHeader.vue
@@ -108,7 +108,7 @@ const artistMoneyRaised = computed(() =>
         </MenuButton>
 
         <template #content>
-          <div class="relative z-60 bg-surface-3 p-2 rounded-[20px]">
+          <div class="relative z-50 bg-surface-3 p-2 rounded-[20px]">
             <MenuItem class="mb-2">
               <router-link to="/account-settings">
                 <div

--- a/ui/src/components/Navigation/NavbarContent.vue
+++ b/ui/src/components/Navigation/NavbarContent.vue
@@ -88,7 +88,7 @@ const joinedCampaigns = computed(() => {
 </script>
 
 <template>
-  <div class="flex w-full flex-col mt-4">
+  <div class="flex w-full flex-col my-4">
     <router-link
       class="button-gradient flex justify-center text-white"
       to="/conjure"

--- a/ui/src/components/Relationships/Graphs/ForceGraph.vue
+++ b/ui/src/components/Relationships/Graphs/ForceGraph.vue
@@ -396,6 +396,12 @@ const viewConjuration = () => {
           Outgoing Relationships
         </div>
       </div>
+      <div
+        v-if="!data.nodes.length"
+        class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-neutral-500"
+      >
+        No Relationships
+      </div>
     </div>
   </div>
 </template>

--- a/ui/src/router/router.ts
+++ b/ui/src/router/router.ts
@@ -4,7 +4,6 @@ import CampaignsView from '@/views/CampaignsView.vue';
 import ListCampaigns from '@/components/Campaigns/ListCampaigns.vue';
 import NewCampaign from '@/components/Campaigns/NewCampaign.vue';
 import ConjuringView from '@/views/ConjuringView.vue';
-import ListConjurers from '@/components/Conjuration/ListConjurers.vue';
 import ViewConjurer from '@/components/Conjuration/ViewConjurer.vue';
 import ViewCampaign from '@/components/Campaigns/ViewCampaign.vue';
 import SessionsView from '@/views/SessionsView.vue';
@@ -143,14 +142,6 @@ const router = createRouter({
               },
             },
             {
-              path: 'new',
-              component: ListConjurers,
-              beforeEnter: authGuard,
-              meta: {
-                paidRequired: true,
-              },
-            },
-            {
               path: 'conjure/:summonerCode',
               component: ViewConjurer,
               beforeEnter: authGuard,
@@ -202,6 +193,10 @@ const router = createRouter({
           beforeEnter: authGuard,
         },
       ],
+    },
+    {
+      path: '/conjurations/new',
+      redirect: '/conjure',
     },
     {
       name: 'CONJURE',

--- a/ui/src/router/router.ts
+++ b/ui/src/router/router.ts
@@ -12,8 +12,6 @@ import ListSessions from '@/components/Sessions/ListSessions.vue';
 import ListConjurations from '@/components/Conjuration/ListConjurations.vue';
 import ViewConjuration from '@/components/Conjuration/ViewConjuration.vue';
 import InviteView from '@/views/InviteView.vue';
-import PreAuthView from '@/views/PreAuthView.vue';
-import EarlyAccessView from '@/views/EarlyAccessView.vue';
 import CharactersList from '@/views/CharactersList.vue';
 import CharactersView from '@/views/CharactersView.vue';
 import CharactersNew from '@/components/Characters/NewCharacter.vue';
@@ -51,6 +49,10 @@ const router = createRouter({
       redirect: '/account-settings',
     },
     {
+      path: '/conjurations/new',
+      redirect: '/conjure',
+    },
+    {
       name: 'AUTH',
       path: '/auth',
       children: [
@@ -58,22 +60,17 @@ const router = createRouter({
           name: 'LOGIN',
           path: 'login',
           component: LoginView,
-          beforeEnter: authGuard,
-        },
-        {
-          name: 'PREAUTH',
-          path: 'preauth',
-          component: PreAuthView,
-        },
-        {
-          name: 'EARLY_ACCESS',
-          path: 'earlyaccess',
-          component: EarlyAccessView,
+          meta: {
+            noAuth: true,
+          },
         },
         {
           name: 'INVITE',
           path: 'invite',
           component: InviteView,
+          meta: {
+            noAuth: true,
+          },
         },
       ],
     },
@@ -193,10 +190,6 @@ const router = createRouter({
           beforeEnter: authGuard,
         },
       ],
-    },
-    {
-      path: '/conjurations/new',
-      redirect: '/conjure',
     },
     {
       name: 'CONJURE',

--- a/ui/src/views/ConjureView.vue
+++ b/ui/src/views/ConjureView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router';
-import { useLDFlag } from 'launchdarkly-vue-client-sdk';
 import { onMounted, ref, watch } from 'vue';
 import MeteorShower from '@/components/Core/MeteorShower.vue';
 import GeneratorSelect from '@/components/Conjure/GeneratorSelect.vue';
@@ -11,7 +10,6 @@ import EditConjurationDetails from '@/components/Conjure/EditConjurationDetails.
 import CreateConjurationImage from '@/components/Conjure/CreateConjurationImage.vue';
 
 const current = ref<'generator' | 'conjure' | 'edit' | 'image'>('generator');
-const conjureV2 = useLDFlag('conjure-v2');
 const router = useRouter();
 const route = useRoute();
 
@@ -20,12 +18,14 @@ const generators = ref<Conjurer[]>([]);
 const conjuration = ref<Conjuration>();
 const defaultPrompt = ref('');
 
-watch(conjureV2, () => {
-  checkConjureV2();
+watch(route, () => {
+  if (route.fullPath === '/conjure') {
+    current.value = 'generator';
+    defaultPrompt.value = '';
+  }
 });
 
 onMounted(async () => {
-  checkConjureV2();
   await loadGenerators();
 
   if (route.query.code) {
@@ -46,12 +46,6 @@ onMounted(async () => {
     current.value = 'generator';
   }
 });
-
-const checkConjureV2 = () => {
-  if (conjureV2.value === false) {
-    router.push({ path: 'conjurations/new', query: route.query });
-  }
-};
 
 const back = () => {
   switch (current.value) {

--- a/ui/src/views/InviteView.vue
+++ b/ui/src/views/InviteView.vue
@@ -84,6 +84,10 @@ function characterDescription(character: any) {
     )?.data.text
   );
 }
+
+const anyCharacters = computed(() => {
+  return invite?.value?.members.some((m) => m.character.length > 0);
+});
 </script>
 
 <template>
@@ -92,7 +96,11 @@ function characterDescription(character: any) {
       v-if="invite && !authStore.tokens"
       class="w-[90vw] md:w-[50vw] p-6 bg-neutral-900 rounded-[20px]"
     >
-      <img src="/images/logo-horizontal-2.svg" class="h-16 w-auto mx-auto" />
+      <img
+        src="/images/logo-horizontal-2.svg"
+        alt="mythweaver logo"
+        class="h-16 w-auto mx-auto"
+      />
 
       <div class="mt-6 text-center text-white text-2xl">
         You've been invited to join
@@ -131,11 +139,10 @@ function characterDescription(character: any) {
       </div>
       <div v-else class="text-center">
         <button class="button-gradient text-lg py-4" @click="register">
-          Create An Account
+          Create A Free MythWeaver Account
         </button>
       </div>
-
-      <div v-if="invite.members.length" class="mt-6 w-full">
+      <div v-if="anyCharacters" class="mt-6 w-full">
         <div class="flex w-full">
           <div class="grow self-center px-2">
             <hr class="border-neutral-700" />

--- a/ui/src/views/InviteView.vue
+++ b/ui/src/views/InviteView.vue
@@ -56,6 +56,17 @@ const acceptInvite = async () => {
   }
 };
 
+const login = async () => {
+  await loginWithRedirect({
+    authorizationParams: {
+      screen_hint: 'login',
+    },
+    appState: {
+      target: `/auth/invite?code=${inviteCode.value}`,
+    },
+  });
+};
+
 const register = async () => {
   await loginWithRedirect({
     authorizationParams: {
@@ -138,7 +149,11 @@ const anyCharacters = computed(() => {
         </button>
       </div>
       <div v-else class="text-center">
-        <button class="button-gradient text-lg py-4" @click="register">
+        <button class="button-gradient text-lg py-2" @click="login">
+          Log In
+        </button>
+        <div class="text-neutral-500 text-lg">Or</div>
+        <button class="button-gradient text-lg py-2" @click="register">
           Create A Free MythWeaver Account
         </button>
       </div>

--- a/ui/src/views/RelationshipGraphView.vue
+++ b/ui/src/views/RelationshipGraphView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { getRelationshipGraph } from '@/api/relationships.ts';
 import { showError } from '@/lib/notifications.ts';
 import Loader from '@/components/Core/Loader.vue';
@@ -7,10 +7,32 @@ import ForceGraph from '@/components/Relationships/Graphs/ForceGraph.vue';
 import { ArrowLeftIcon } from '@heroicons/vue/24/solid';
 import { useRoute } from 'vue-router';
 import router from '@/router/router.ts';
+import { useCurrentUserId } from '@/lib/hooks.ts';
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/vue/20/solid';
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue';
+import { storeToRefs } from 'pinia';
+import { useCampaignStore } from '@/store/campaign.store.ts';
 
 const route = useRoute();
 const loading = ref(true);
 const data = ref<any>(undefined);
+const campaignStore = useCampaignStore();
+const currentUserId = useCurrentUserId();
+const { campaigns } = storeToRefs(campaignStore);
+
+const campaignId = ref();
+
+const myCampaigns = computed(() => {
+  return campaigns.value.filter((c: any) => c.userId === currentUserId.value);
+});
+
+const selectedCampaign = computed(() => {
+  return myCampaigns.value.find((c: any) => c.id === campaignId.value);
+});
+
+watch(campaignId, () => {
+  fetchGraphData();
+});
 
 onMounted(async () => {
   await fetchGraphData();
@@ -20,7 +42,7 @@ async function fetchGraphData() {
   loading.value = true;
 
   try {
-    const response = await getRelationshipGraph();
+    const response = await getRelationshipGraph(campaignId.value);
     data.value = {
       nodes: response.data.nodes,
       links: response.data.links,
@@ -45,7 +67,7 @@ const back = () => {
 
 <template>
   <div class="h-full w-full">
-    <div class="flex justify-between mb-4">
+    <div class="flex flex-wrap justify-between mb-4">
       <div class="flex gap-2">
         <button class="button-primary flex self-center" @click="back">
           <ArrowLeftIcon class="mr-2 h-4 w-4 self-center" />
@@ -54,6 +76,98 @@ const back = () => {
         <div class="text-lg gradient-text self-center">
           Conjuration Relationships
         </div>
+      </div>
+      <div>
+        <Menu v-model="campaignId" class="my-0.5 min-w-[12em]">
+          <div class="relative mt-1">
+            <MenuButton
+              class="relative h-10 w-full cursor-pointer rounded-xl pl-4 pr-8 text-left text-white flex items-center text-sm border border-surface-3 hover:bg-purple-800/20"
+            >
+              <span class="block truncate">{{
+                selectedCampaign?.name || 'Show All'
+              }}</span>
+              <span
+                class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
+              >
+                <ChevronUpDownIcon
+                  class="h-5 w-5 text-white"
+                  aria-hidden="true"
+                />
+              </span>
+            </MenuButton>
+
+            <transition
+              leave-active-class="transition duration-100 ease-in"
+              leave-from-class="opacity-100"
+              leave-to-class="opacity-0"
+            >
+              <MenuItems
+                class="default-border-no-opacity w-full absolute mt-1 max-h-60 max-w-[300px] z-50 overflow-auto rounded-md py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none text-sm"
+              >
+                <MenuItem
+                  v-slot="{ active }"
+                  key="Show All"
+                  as="template"
+                  :value="undefined"
+                  @click="campaignId = undefined"
+                >
+                  <div
+                    class="cursor-pointer"
+                    :class="[
+                      active
+                        ? 'bg-purple-800/20 text-purple-200'
+                        : 'text-white',
+                      'relative flex justify-between cursor-default select-none py-2 pl-4',
+                    ]"
+                  >
+                    <span> Show All </span>
+                  </div>
+                </MenuItem>
+                <div
+                  v-if="myCampaigns.length"
+                  class="text-xs text-neutral-500 px-4 pt-2"
+                >
+                  <div>Campaign Collections</div>
+                  <hr class="border-neutral-600" />
+                </div>
+                <MenuItem
+                  v-for="campaign in myCampaigns"
+                  v-slot="{ active }"
+                  :key="campaign.name"
+                  :value="campaign.id"
+                  as="template"
+                >
+                  <div
+                    class="cursor-pointer"
+                    :class="[
+                      active
+                        ? 'bg-purple-800/20 text-purple-200'
+                        : 'text-white',
+                      'relative cursor-default select-none py-2 rl-10 pl-4 pr-8',
+                    ]"
+                    @click="campaignId = campaign.id"
+                  >
+                    <span
+                      :class="[
+                        selectedCampaign?.id === campaign.id
+                          ? 'font-medium'
+                          : 'font-normal',
+                        'block truncate',
+                      ]"
+                      >{{ campaign.name }}</span
+                    >
+                    <span
+                      v-if="selectedCampaign?.id === campaign.id"
+                      class="absolute inset-y-0 right-0 flex items-center pr-2 text-purple-300"
+                    >
+                      <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                    </span>
+                  </div>
+                </MenuItem>
+              </MenuItems>
+            </transition>
+          </div>
+        </Menu>
       </div>
     </div>
     <div v-if="loading" class="flex justify-center">


### PR DESCRIPTION
Show if a conjuration is already added to a collection
Make conjuration websocket events more contextual
Allow filtering relationship graph by campaign
Added empty state for relationship graph
Add better loading for conjuration lists
Stripping out some launch darkly feature flags that aren't needed anymore
Moved conjuration type badge into tags
Fixed issue where clicking navbar 'conjure' button while currently in conjure workflow would not take you back to beginning step